### PR TITLE
fetch the lastest version of lein

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:7
 MAINTAINER Paul Lam <paul@quantisan.com>
 
-RUN curl -s https://raw.githubusercontent.com/technomancy/leiningen/2.4.3/bin/lein > \
+RUN curl -s https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > \
             /usr/local/bin/lein && \
             chmod 0755 /usr/local/bin/lein
 ENV LEIN_ROOT 1


### PR DESCRIPTION
This branch will just download the last stable version of Lein, so we do not have to change the code all the time a new version is rolled out.
