### PR TITLE
add the last static version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:7
 MAINTAINER Paul Lam <paul@quantisan.com>
 
-RUN curl -s https://raw.githubusercontent.com/technomancy/leiningen/2.4.3/bin/lein > \
+RUN curl -s https://raw.githubusercontent.com/technomancy/leiningen/2.5.0/bin/lein > \
             /usr/local/bin/lein && \
             chmod 0755 /usr/local/bin/lein
 ENV LEIN_ROOT 1


### PR DESCRIPTION
This branch will download the last static version of Lein, it is the lastes version but when a new lein will roll out we will need to update the code.
