### PR TITLE
Bump lein to 2.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:8
 MAINTAINER Paul Lam <paul@quantisan.com>
 
-ENV LEIN_VERSION=2.5.1
+ENV LEIN_VERSION=2.5.2
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -10,7 +10,7 @@ WORKDIR /tmp
 RUN mkdir -p $LEIN_INSTALL \
   && wget --quiet https://github.com/technomancy/leiningen/archive/$LEIN_VERSION.tar.gz \
   && echo "Comparing archive checksum ..." \
-  && echo "4f6e2e189be0a163f400c3a8060896285fe731f7 *$LEIN_VERSION.tar.gz" | sha1sum -c - \
+  && echo "f286d3e61fec48ad2d52af1d8f23debc77cf7581 *$LEIN_VERSION.tar.gz" | sha1sum -c - \
 
   && mkdir ./leiningen \
   && tar -xzf $LEIN_VERSION.tar.gz  -C ./leiningen/ --strip-components=1 \
@@ -23,8 +23,7 @@ RUN mkdir -p $LEIN_INSTALL \
   && wget --quiet https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
   && wget --quiet https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \
 
-  && gpg --keyserver pool.sks-keyservers.net --recv-keys \
-    296F37E451F91ED1783E402792893DA43FC33005 \
+  && gpg --keyserver pool.sks-keyservers.net --recv-key 05696D78 \
   && echo "Verifying Jar file signature ..." \
   && gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc \
 


### PR DESCRIPTION
Update Leiningen with v2.5.2 (refs #14)
But strange gpg output:

```
Comparing archive checksum ...
2.5.2.tar.gz: OK
gpg: directory `/root/.gnupg' created
gpg: new configuration file `/root/.gnupg/gpg.conf' created
gpg: WARNING: options in `/root/.gnupg/gpg.conf' are not yet active during this run
gpg: keyring `/root/.gnupg/secring.gpg' created
gpg: keyring `/root/.gnupg/pubring.gpg' created
gpg: requesting key 05696D78 from hkp server pool.sks-keyservers.net
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 05696D78: public key "Jean Niklas L'orange (hyPiRion) <jeannikl@hypirion.com>" imported
gpg: no ultimately trusted keys found
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
Verifying Jar file signature ...
gpg: assuming signed data in `leiningen-2.5.2-standalone.zip'
gpg: Signature made Sun 09 Aug 2015 01:30:47 PM UTC using RSA key ID 05696D78
gpg: Good signature from "Jean Niklas L'orange (hyPiRion) <jeannikl@hypirion.com>"
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 2E70 8FB2 FCEC A07F F818  4E27 5A92 E043 0569 6D78
```
Is it normal?