### PR TITLE
Add rlfe for REPL usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,10 @@ RUN mkdir -p $LEIN_INSTALL \
 
 # Put the jar where lein script expects
   && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
-  && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
+  && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar \
 
 # Some REPLs (e.g., Figwheel) necessitate a readline wrapper.
-RUN apt-get update && apt-get install rlfe && rm -rf /var/lib/apt/lists/*
+  &&  apt-get update && apt-get install rlfe && rm -rf /var/lib/apt/lists/*
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN mkdir -p $LEIN_INSTALL \
   && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
   && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 
+# Some REPLs (e.g., Figwheel) necessitate a readline wrapper.
+RUN apt-get update && apt-get install rlfe && rm -rf /var/lib/apt/lists/*
+
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,22 @@ docker run -it --rm --name running-clojure-app my-clojure-app
 ### Isolated Development with [Fig](http://www.fig.sh/)
 
 See [this repository for instruction and example](https://github.com/Quantisan/clojure-getting-started).
+
+### ClojureScript Development with [Figwheel](https://github.com/bhauman/lein-figwheel) ###
+
+Run Figwheel to automatically load your ClojureScript changes into your running browser window.
+
+```
+docker run --rm -it \
+  -w /w -v "$PWD":/w \
+  -v "$HOME"/.m2:/root/.m2 \
+  -p 3449:3449 \
+  clojure \
+  rlfe lein figwheel
+```
+
+Notes:
+- Mounts $HOME/.m2 for caching Maven jars.
+- Exposes port 3449 (the default port for Figwheel) so the client code running in your browser can connect to it.
+- Wraps Figwheel's REPL in `rlfe` so command history and standard key combinations are available
+- If you're using a virtual machine, be sure to set Figwheel's `:websocket-url` option in your project.clj to something that makes sense (e.g., `ws://192.168.99.100:3449/figwheel-ws`).


### PR DESCRIPTION
We would love to use this docker image to build ClojureScript applications, but it is useless without a readline wrapper for Figwheel's browser REPL. Is this change a possibility?