### PR TITLE
Stop installing rlwrap in alpine build

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -33,11 +33,7 @@ RUN mkdir -p $LEIN_INSTALL \
 # Put the jar where lein script expects
   && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
   && mkdir -p /usr/share/java \
-  && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar \
-
-# Some REPLs (e.g., Figwheel) necessitate a readline wrapper.
-  && apk add rlwrap --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
-  && rm -rf /var/cache/apk/*
+  && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1


### PR DESCRIPTION
This is a less-is-more build, so users who need rlwrap (or similar) can
either install it themselves or stick with the Ubuntu-based image.

As requested in the [docker-library pull request](https://github.com/docker-library/official-images/pull/1587#issuecomment-205453648).