### PR TITLE
Add boot variants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,23 @@
 FROM openjdk:8
 MAINTAINER Paul Lam <paul@quantisan.com>
 
-ENV LEIN_VERSION=2.7.1
-ENV LEIN_INSTALL=/usr/local/bin/
+ARG BUILD_TOOL=lein
+ARG TOOL_VERSION
+ENV TOOL_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
 
-# Download the whole repo as an archive
-RUN mkdir -p $LEIN_INSTALL \
-  && wget --quiet https://github.com/technomancy/leiningen/archive/$LEIN_VERSION.tar.gz \
-  && echo "Comparing archive checksum ..." \
-  && echo "876221e884780c865c2ce5c9aa5675a7cae9f215 *$LEIN_VERSION.tar.gz" | sha1sum -c - \
+COPY ./install-${BUILD_TOOL}.sh install-build-tool.sh
 
-  && mkdir ./leiningen \
-  && tar -xzf $LEIN_VERSION.tar.gz  -C ./leiningen/ --strip-components=1 \
-  && mv leiningen/bin/lein-pkg $LEIN_INSTALL/lein \
-  && rm -rf $LEIN_VERSION.tar.gz ./leiningen \
-
-  && chmod 0755 $LEIN_INSTALL/lein \
-
-# Download and verify Lein stand-alone jar
-  && wget --quiet https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
-  && wget --quiet https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \
-
-  && gpg --keyserver pool.sks-keyservers.net --recv-key 2E708FB2FCECA07FF8184E275A92E04305696D78 \
-  && echo "Verifying Jar file signature ..." \
-  && gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc \
-
-# Put the jar where lein script expects
-  && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
-  && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar \
-
-# Some REPLs (e.g., Figwheel) necessitate a readline wrapper.
-  &&  apt-get update && apt-get install rlfe && rm -rf /var/lib/apt/lists/*
-
-ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
+ENV BOOT_AS_ROOT yes
+ENV BOOT_VERSION $TOOL_VERSION
 
-RUN lein
+RUN mkdir -p $TOOL_INSTALL \
+  && chmod +x install-build-tool.sh \
+  && ./install-build-tool.sh \
+  && rm install-build-tool.sh
+
+ENV PATH=$PATH:$TOOL_INSTALL
+
+RUN $BUILD_TOOL

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8
 MAINTAINER Paul Lam <paul@quantisan.com>
 
 ARG BUILD_TOOL=lein
-ARG TOOL_VERSION
+ARG TOOL_VERSION=2.7.1
 ENV TOOL_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,41 +1,26 @@
-FROM openjdk:8u111-alpine
+FROM openjdk:8-alpine
 MAINTAINER Wes Morgan <wesmorgan@icloud.com>
 
-ENV LEIN_VERSION=2.7.1
-ENV LEIN_INSTALL=/usr/local/bin/
+ARG BUILD_TOOL=lein
+ARG TOOL_VERSION=2.7.1
+ENV TOOL_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
+
+COPY ./install-${BUILD_TOOL}.sh install-build-tool.sh
+
+ENV LEIN_ROOT 1
+ENV BOOT_AS_ROOT yes
+ENV BOOT_VERSION $TOOL_VERSION
 
 # Install real tar as BusyBox's doesn't support --strip-components
 RUN apk add --update tar gnupg bash openssl && rm -rf /var/cache/apk/*
 
-# Download the whole repo as an archive
-RUN mkdir -p $LEIN_INSTALL \
-  && wget -q https://github.com/technomancy/leiningen/archive/$LEIN_VERSION.tar.gz \
-  && echo "Comparing archive checksum ..." \
-  && echo "876221e884780c865c2ce5c9aa5675a7cae9f215 *$LEIN_VERSION.tar.gz" | sha1sum -c - \
+RUN mkdir -p $TOOL_INSTALL \
+  && chmod +x install-build-tool.sh \
+  && ./install-build-tool.sh \
+  && rm install-build-tool.sh
 
-  && mkdir ./leiningen \
-  && tar -xzf $LEIN_VERSION.tar.gz  -C ./leiningen/ --strip-components=1 \
-  && mv leiningen/bin/lein-pkg $LEIN_INSTALL/lein \
-  && rm -rf $LEIN_VERSION.tar.gz ./leiningen \
+ENV PATH=$PATH:$TOOL_INSTALL
 
-  && chmod 0755 $LEIN_INSTALL/lein \
-
-# Download and verify Lein stand-alone jar
-  && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
-  && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \
-
-  && gpg --keyserver pool.sks-keyservers.net --recv-key 2E708FB2FCECA07FF8184E275A92E04305696D78 \
-  && echo "Verifying Jar file signature ..." \
-  && gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc \
-
-# Put the jar where lein script expects
-  && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
-  && mkdir -p /usr/share/java \
-  && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
-
-ENV PATH=$PATH:$LEIN_INSTALL
-ENV LEIN_ROOT 1
-
-RUN lein
+RUN $BUILD_TOOL

--- a/install-boot.sh
+++ b/install-boot.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+# Download boot
+wget --quiet https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh
+mv boot.sh $TOOL_INSTALL/boot
+chmod +x $TOOL_INSTALL/boot
+
+# Run REPL to install nrepl deps
+$TOOL_INSTALL/boot repl -e '(System/exit 0)'

--- a/install-boot.sh
+++ b/install-boot.sh
@@ -3,9 +3,10 @@
 set -e
 
 # Download boot
-wget --quiet https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh
+wget -q https://github.com/boot-clj/boot-bin/releases/download/2.5.2/boot.sh
+echo "Comparing checksum..."
+echo "d9cbefc6cbf043361a58b416e6d62fc80e5ead32 *boot.sh" | sha1sum -c -
+
+# Install boot
 mv boot.sh $TOOL_INSTALL/boot
 chmod +x $TOOL_INSTALL/boot
-
-# Run REPL to install nrepl deps
-$TOOL_INSTALL/boot repl -e '(System/exit 0)'

--- a/install-lein.sh
+++ b/install-lein.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Download the whole repo as an archive
-wget --quiet https://github.com/technomancy/leiningen/archive/$TOOL_VERSION.tar.gz
+wget -q https://github.com/technomancy/leiningen/archive/$TOOL_VERSION.tar.gz
 echo "Comparing archive checksum ..."
 echo "876221e884780c865c2ce5c9aa5675a7cae9f215 *$TOOL_VERSION.tar.gz" | sha1sum -c -
 
@@ -15,8 +15,8 @@ rm -rf $TOOL_VERSION.tar.gz ./leiningen
 chmod 0755 $TOOL_INSTALL/lein
 
 # Download and verify Lein stand-alone jar
-wget --quiet https://github.com/technomancy/leiningen/releases/download/$TOOL_VERSION/leiningen-$TOOL_VERSION-standalone.zip
-wget --quiet https://github.com/technomancy/leiningen/releases/download/$TOOL_VERSION/leiningen-$TOOL_VERSION-standalone.zip.asc
+wget -q https://github.com/technomancy/leiningen/releases/download/$TOOL_VERSION/leiningen-$TOOL_VERSION-standalone.zip
+wget -q https://github.com/technomancy/leiningen/releases/download/$TOOL_VERSION/leiningen-$TOOL_VERSION-standalone.zip.asc
 
 gpg --keyserver pool.sks-keyservers.net --recv-key 2E708FB2FCECA07FF8184E275A92E04305696D78
 echo "Verifying Jar file signature ..."
@@ -24,7 +24,5 @@ gpg --verify leiningen-$TOOL_VERSION-standalone.zip.asc
 
 # Put the jar where lein script expects
 rm leiningen-$TOOL_VERSION-standalone.zip.asc
+mkdir -p /usr/share/java
 mv leiningen-$TOOL_VERSION-standalone.zip /usr/share/java/leiningen-$TOOL_VERSION-standalone.jar
-
-# Some REPLs (e.g., Figwheel) necessitate a readline wrapper.
-apt-get update && apt-get install rlfe && rm -rf /var/lib/apt/lists/*

--- a/install-lein.sh
+++ b/install-lein.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -e
+
+# Download the whole repo as an archive
+wget --quiet https://github.com/technomancy/leiningen/archive/$TOOL_VERSION.tar.gz
+echo "Comparing archive checksum ..."
+echo "876221e884780c865c2ce5c9aa5675a7cae9f215 *$TOOL_VERSION.tar.gz" | sha1sum -c -
+
+mkdir ./leiningen
+tar -xzf $TOOL_VERSION.tar.gz  -C ./leiningen/ --strip-components=1
+mv leiningen/bin/lein-pkg $TOOL_INSTALL/lein
+rm -rf $TOOL_VERSION.tar.gz ./leiningen
+
+chmod 0755 $TOOL_INSTALL/lein
+
+# Download and verify Lein stand-alone jar
+wget --quiet https://github.com/technomancy/leiningen/releases/download/$TOOL_VERSION/leiningen-$TOOL_VERSION-standalone.zip
+wget --quiet https://github.com/technomancy/leiningen/releases/download/$TOOL_VERSION/leiningen-$TOOL_VERSION-standalone.zip.asc
+
+gpg --keyserver pool.sks-keyservers.net --recv-key 2E708FB2FCECA07FF8184E275A92E04305696D78
+echo "Verifying Jar file signature ..."
+gpg --verify leiningen-$TOOL_VERSION-standalone.zip.asc
+
+# Put the jar where lein script expects
+rm leiningen-$TOOL_VERSION-standalone.zip.asc
+mv leiningen-$TOOL_VERSION-standalone.zip /usr/share/java/leiningen-$TOOL_VERSION-standalone.jar
+
+# Some REPLs (e.g., Figwheel) necessitate a readline wrapper.
+apt-get update && apt-get install rlfe && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Opening this for discussion about the approach. This would close #19.

I added build args (w/ defaults for current behavior) that allow building images with any version of either boot or leiningen.

I'm thinking we could publish more image tags along the lines of:

- `docker build -t clojure:lein-2.7.1 .` same as now
- `docker build -t clojure:lein-2.7.1-alpine alpine` same as now
- `docker build -t clojure:boot-2.7.1 --build-arg BUILD_TOOL=boot --build-arg TOOL_VERSION=2.7.1 .` will build a boot-based image; note that boot and lein's latest versions happen to be in sync right now but presumably that won't always be the case
- `docker build -t clojure:boot-2.7.1-alpine --build-arg BUILD_TOOL=boot --build-arg TOOL_VERSION=2.7.1 alpine` will build an alpine-based image w/ boot instead of lein

Note: This no longer installs the `rlwrap` package that master's non-alpine image currently has. The reasoning for leaving it out of the alpine-based image seemed applicable to the non-alpine one too (i.e. that it just adds bloat for those who don't need it and those who do can install it themselves).