### PR TITLE
Hooks and readme updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+hooks

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 This is the repository for the [official Docker image for Clojure](https://registry.hub.docker.com/_/clojure/).
 It is automatically pulled and built by Stackbrew into the Docker registry.
-This image runs on OpenJDK 8 and includes Leiningen.
+This image runs on OpenJDK 8 and includes [Leiningen](http://leiningen.org) or [boot](http://boot-clj.com) (see below for tags and building instructions).
+
+## Leiningen vs. boot
+
+The version tags on these images look like `lein-N.N.N(-alpine)` and `boot-N.N.N(-alpine)`. These refer to which version of Leiningen or boot is packaged in the image (because they can then install and use any version of Clojure at runtime). The default `latest` (or `lein`, `lein-alpine`) images will always have a recent version of Leiningen installed. If you want boot, specify either `clojure:boot`, `clojure:boot-alpine`, or `clojure:boot-N.N.N` / `clojure:boot-N.N.N-alpine` (where `N.N.N` is the version of boot you want installed).
 
 ## Examples
 
@@ -30,10 +34,10 @@ This image makes building derivative images easier. For most use cases, creating
 
 These images are based on the minimalist Alpine Linux distribution and are much smaller than the default (Debian-based) images. If your app can run in them, they will be much faster to transfer and take up much less space.
 
-#### Pull or build this image
+### On-build triggers
 
 ```
-docker build --rm -t clojure:onbuild onbuild
+docker build -t clojure:onbuild onbuild
 ```
 
 #### Create a `Dockerfile` in your Clojure app project
@@ -70,3 +74,27 @@ Notes:
 - Mounts $HOME/.m2 for caching Maven jars.
 - Exposes port 3449 (the default port for Figwheel) so the client code running in your browser can connect to it.
 - If you're using a virtual machine, be sure to set Figwheel's `:websocket-url` option in your project.clj to something that makes sense (e.g., `ws://192.168.99.100:3449/figwheel-ws`).
+
+## Builds
+
+The choice between leiningen and boot is determined at build-time via the BUILD_TOOL build arg. It defaults to `lein` if not set. You can also specify the version of the build tool you'd like to install via the TOOL_VERSION build arg.
+
+### Build examples
+
+#### boot
+
+```
+docker build -t clojure:boot-2.7.1 \
+  --build-arg BUILD_TOOL=boot \
+  --build-arg TOOL_VERSION=2.7.1 \
+  .
+```
+
+#### Alpine-based leiningen
+
+```
+docker build -t clojure:lein-2.7.1-alpine \
+  --build-arg BUILD_TOOL=lein \
+  --build-arg TOOL_VERSION=2.7.1 \
+  alpine
+```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Put this file in the root of your app.
 
 This image includes multiple `ONBUILD` triggers which should be all you need to bootstrap most applications. The build will `COPY . /usr/src/app` and `RUN lein deps`
 
-You can then build and run the CLojure image:
+You can then build and run the Clojure image:
 
 ```
 docker build -t my-clojure-app .

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ lein repl
 
 This image makes building derivative images easier. For most use cases, creating a Dockerfile in the base of your project directory with the line `FROM clojure:onbuild` will be enough to create a stand-alone image for your project.
 
+### `clojure:alpine` & `clojure:alpine-onbuild`
+
+These images are based on the minimalist Alpine Linux distribution and are much smaller than the default (Debian-based) images. If your app can run in them, they will be much faster to transfer and take up much less space.
+
 #### Pull or build this image
 
 ```

--- a/README.md
+++ b/README.md
@@ -67,11 +67,10 @@ docker run --rm -it \
   -v "$HOME"/.m2:/root/.m2 \
   -p 3449:3449 \
   clojure \
-  rlfe lein figwheel
+  lein figwheel
 ```
 
 Notes:
 - Mounts $HOME/.m2 for caching Maven jars.
 - Exposes port 3449 (the default port for Figwheel) so the client code running in your browser can connect to it.
-- Wraps Figwheel's REPL in `rlfe` so command history and standard key combinations are available
 - If you're using a virtual machine, be sure to set Figwheel's `:websocket-url` option in your project.clj to something that makes sense (e.g., `ws://192.168.99.100:3449/figwheel-ws`).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ docker build --rm -t clojure:onbuild onbuild
 
 ```
 FROM clojure:onbuild
-CMD ["lein", "run"]
 ```
 
 Put this file in the root of your app.

--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ docker build -t my-clojure-app .
 docker run -it --rm --name running-clojure-app my-clojure-app
 ```
 
-### Isolated Development with [Fig](http://www.fig.sh/)
-
-See [this repository for instruction and example](https://github.com/Quantisan/clojure-getting-started).
-
 ### ClojureScript Development with [Figwheel](https://github.com/bhauman/lein-figwheel) ###
 
 Run Figwheel to automatically load your ClojureScript changes into your running browser window.

--- a/hooks/build
+++ b/hooks/build
@@ -10,6 +10,7 @@ fi
 
 if [[ $DOCKER_TAG == "lein-"* || $DOCKER_TAG == "boot-"* ]]; then
   TOOL_VERSION=${DOCKER_TAG#*-}
+  TOOL_VERSION=${TOOL_VERSION%-*}
 fi
 
 BUILD_CMD="docker build -t $IMAGE_NAME \

--- a/hooks/build
+++ b/hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 if [[ $DOCKER_TAG == "boot"* ]]; then
   BUILD_TOOL=boot
@@ -8,9 +8,13 @@ else
   BUILD_TOOL=lein
 fi
 
-TOOL_VERSION=${DOCKER_TAG#*-}
+if [[ $DOCKER_TAG == "lein-"* || $DOCKER_TAG == "boot-"* ]]; then
+  TOOL_VERSION=${DOCKER_TAG#*-}
+fi
 
-docker build -t $IMAGE_NAME \
-             --build-arg BUILD_TOOL=$BUILD_TOOL \
-             --build-arg TOOL_VERSION=$TOOL_VERSION \
-             $BUILD_PATH
+BUILD_CMD="docker build -t $IMAGE_NAME \
+  --build-arg BUILD_TOOL=$BUILD_TOOL \
+  $(if [[ -n $TOOL_VERSION ]]; then echo --build-arg TOOL_VERSION=$TOOL_VERSION; fi) \
+  $BUILD_PATH"
+
+$BUILD_CMD

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+if [[ $DOCKER_TAG == "boot"* ]]; then
+  BUILD_TOOL=boot
+else
+  BUILD_TOOL=lein
+fi
+
+TOOL_VERSION=${DOCKER_TAG#*-}
+
+docker build -t $IMAGE_NAME \
+             --build-arg BUILD_TOOL=$BUILD_TOOL \
+             --build-arg TOOL_VERSION=$TOOL_VERSION \
+             $BUILD_PATH

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+if [[ $DOCKER_TAG == "boot"* ]]; then
+  BUILD_TOOL=boot
+else
+  BUILD_TOOL=lein
+fi
+
+if [[ $DOCKER_TAG == *"alpine"* ]]; then
+  NEW_TAG="${BUILD_TOOL}-alpine"
+else
+  NEW_TAG=$BUILD_TOOL
+fi
+
+docker tag $IMAGE_NAME $DOCKER_REPO:$NEW_TAG
+docker push $DOCKER_REPO:$NEW_TAG

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 if [[ $DOCKER_TAG == "boot"* ]]; then
   BUILD_TOOL=boot
@@ -8,10 +8,12 @@ else
   BUILD_TOOL=lein
 fi
 
-if [[ $DOCKER_TAG == *"alpine"* ]]; then
-  NEW_TAG="${BUILD_TOOL}-alpine"
-else
-  NEW_TAG=$BUILD_TOOL
+if [[ $DOCKER_TAG == "lein"* || $DOCKER_TAG == "boot"* ]]; then
+  if [[ $DOCKER_TAG == *"alpine"* ]]; then
+    NEW_TAG="${BUILD_TOOL}-alpine"
+  else
+    NEW_TAG=$BUILD_TOOL
+  fi
 fi
 
 docker tag $IMAGE_NAME $DOCKER_REPO:$NEW_TAG


### PR DESCRIPTION
This contains updates and edits to the README for Alpine-based images, the new leiningen vs. boot images, and other misc. fixes and cleanups.

It also appears that in order to use build args in automated Docker Hub builds, we need to use a build hook. The post_push hook was added to push `clojure:lein`, `clojure:lein-alpine`, `clojure:boot`, and `clojure:boot-alpine` tags as well.