### PR TITLE
Re-adds readline wrapper to make Figwheel usage possible again

### DIFF
--- a/Dockerfile-lein.template
+++ b/Dockerfile-lein.template
@@ -37,4 +37,16 @@ RUN mkdir -p $LEIN_INSTALL \
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
+# Some REPLs (e.g., Figwheel) necessitate a readline wrapper.
+%%DEBIAN%% RUN apt-get update && apt-get install -y rlwrap && rm -rf /var/lib/apt/lists/*
+%%ALPINE%% RUN apk --no-cache add gcc ncurses-dev libc-dev readline-dev make \
+%%ALPINE%%   && cd /tmp \
+%%ALPINE%%   && wget https://github.com/hanslub42/rlwrap/releases/download/v0.43/rlwrap-0.43.tar.gz \
+%%ALPINE%%   && tar -xzvf rlwrap-0.43.tar.gz \
+%%ALPINE%%   && cd rlwrap-0.43 \
+%%ALPINE%%   && ./configure \
+%%ALPINE%%   && make install \
+%%ALPINE%%   && rm -rf rlwrap-0.43 \
+%%ALPINE%%   && apk del gcc ncurses-dev libc-dev readline-dev make
+
 RUN lein

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker run --rm -it \
   -v "$HOME"/.m2:/root/.m2 \
   -p 3449:3449 \
   clojure \
-  lein figwheel
+  sh -c 'sleep 1; rlwrap lein figwheel'
 ```
 
 Notes:

--- a/alpine/lein/Dockerfile
+++ b/alpine/lein/Dockerfile
@@ -43,4 +43,15 @@ RUN mkdir -p $LEIN_INSTALL \
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
+# Some REPLs (e.g., Figwheel) necessitate a readline wrapper.
+RUN apk --no-cache add gcc ncurses-dev libc-dev readline-dev make \
+  && cd /tmp \
+  && wget https://github.com/hanslub42/rlwrap/releases/download/v0.43/rlwrap-0.43.tar.gz \
+  && tar -xzvf rlwrap-0.43.tar.gz \
+  && cd rlwrap-0.43 \
+  && ./configure \
+  && make install \
+  && rm -rf rlwrap-0.43 \
+  && apk del gcc ncurses-dev libc-dev readline-dev make
+
 RUN lein

--- a/debian/lein/Dockerfile
+++ b/debian/lein/Dockerfile
@@ -41,4 +41,7 @@ RUN mkdir -p $LEIN_INSTALL \
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
+# Some REPLs (e.g., Figwheel) necessitate a readline wrapper.
+RUN apt-get update && apt-get install -y rlwrap && rm -rf /var/lib/apt/lists/*
+
 RUN lein

--- a/update.sh
+++ b/update.sh
@@ -63,5 +63,11 @@ for variant in "${variants[@]}"; do
       sed -i '' '/^%%ALPINE%%/d' "$dir/Dockerfile"
       sed -i '' '/^$/N;/^\n$/D' "$dir/Dockerfile"
     fi
+    if [ "$base_variant" = "debian" ]; then
+      sed -i '' 's/^%%DEBIAN%% //g' "$dir/Dockerfile"
+    else
+      sed -i '' '/^%%DEBIAN%%/d' "$dir/Dockerfile"
+      sed -i '' '/^$/N;/^\n$/D' "$dir/Dockerfile"
+    fi
   )
 done


### PR DESCRIPTION
[This commit](https://github.com/Quantisan/docker-clojure/commit/cda0322117453a3d189abc23e44b6901fdaa2998) removed `rlfe` from the lein build, effectively making Figwheel unusable from this image. This PR adds `rlwrap` (another readline wrapper) to both the alpine and debian lein builds to restore the functionality.

Since the README still contains a Figwheel example, my assumption is that this breakage was inadvertent.