### PR TITLE
Add clojure 1.8.0 jar in lein images

### DIFF
--- a/Dockerfile-lein.template
+++ b/Dockerfile-lein.template
@@ -37,4 +37,6 @@ RUN mkdir -p $LEIN_INSTALL \
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-RUN lein
+# Install clojure 1.8.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.8.0"]])' > project.clj \
+  && lein deps && rm project.clj

--- a/alpine/lein/Dockerfile
+++ b/alpine/lein/Dockerfile
@@ -43,4 +43,6 @@ RUN mkdir -p $LEIN_INSTALL \
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-RUN lein
+# Install clojure 1.8.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.8.0"]])' > project.clj \
+  && lein deps && rm project.clj

--- a/debian/lein/Dockerfile
+++ b/debian/lein/Dockerfile
@@ -41,4 +41,6 @@ RUN mkdir -p $LEIN_INSTALL \
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-RUN lein
+# Install clojure 1.8.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.8.0"]])' > project.clj \
+  && lein deps && rm project.clj


### PR DESCRIPTION
The boot images come with a few jars pre-installed, clojure 1.8.0 among them, due to the way boot works. Installing the latest stable release clojure jar seems like a good thing to do for the lein images too. After this change, you can run the lein images w/ `lein repl` as the command and the REPL will come up without having to download anything. And it saves every downstream build from needing to re-install the basic language jars every time (assuming they're on version 1.8.0).

Curious what you think about this, @Quantisan.