### PR TITLE
Update leiningen to 2.8.0

### DIFF
--- a/Dockerfile-lein.template
+++ b/Dockerfile-lein.template
@@ -1,7 +1,7 @@
 FROM openjdk:%%BASE_TAG%%
 MAINTAINER %%MAINTAINER%%
 
-ENV LEIN_VERSION=2.7.1
+ENV LEIN_VERSION=2.8.0
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -12,24 +12,17 @@ WORKDIR /tmp
 RUN mkdir -p $LEIN_INSTALL \
   && wget -q https://github.com/technomancy/leiningen/archive/$LEIN_VERSION.tar.gz \
   && echo "Comparing archive checksum ..." \
-  && echo "876221e884780c865c2ce5c9aa5675a7cae9f215 *$LEIN_VERSION.tar.gz" | sha1sum -c - \
-
+  && echo "6fe90ca265f43f574f665a9146a443574280928e *$LEIN_VERSION.tar.gz" | sha1sum -c - \
   && mkdir ./leiningen \
   && tar -xzf $LEIN_VERSION.tar.gz  -C ./leiningen/ --strip-components=1 \
   && mv leiningen/bin/lein-pkg $LEIN_INSTALL/lein \
   && rm -rf $LEIN_VERSION.tar.gz ./leiningen \
-
   && chmod 0755 $LEIN_INSTALL/lein \
-
-# Download and verify Lein stand-alone jar
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \
-
-  && gpg --keyserver pool.sks-keyservers.net --recv-key 2E708FB2FCECA07FF8184E275A92E04305696D78 \
+  && gpg --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 \
   && echo "Verifying Jar file signature ..." \
   && gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc \
-
-# Put the jar where lein script expects
   && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
   && mkdir -p /usr/share/java \
   && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar

--- a/Dockerfile-lein.template
+++ b/Dockerfile-lein.template
@@ -10,13 +10,10 @@ WORKDIR /tmp
 
 # Download the whole repo as an archive
 RUN mkdir -p $LEIN_INSTALL \
-  && wget -q https://github.com/technomancy/leiningen/archive/$LEIN_VERSION.tar.gz \
-  && echo "Comparing archive checksum ..." \
-  && echo "6fe90ca265f43f574f665a9146a443574280928e *$LEIN_VERSION.tar.gz" | sha1sum -c - \
-  && mkdir ./leiningen \
-  && tar -xzf $LEIN_VERSION.tar.gz  -C ./leiningen/ --strip-components=1 \
-  && mv leiningen/bin/lein-pkg $LEIN_INSTALL/lein \
-  && rm -rf $LEIN_VERSION.tar.gz ./leiningen \
+  && wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg \
+  && echo "Comparing lein-pkg checksum ..." \
+  && echo "2efff6ca3a77d66d041d705abf7a92cb7efafabb *lein-pkg" | sha1sum -c - \
+  && mv lein-pkg $LEIN_INSTALL/lein \
   && chmod 0755 $LEIN_INSTALL/lein \
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \

--- a/alpine/lein/Dockerfile
+++ b/alpine/lein/Dockerfile
@@ -16,13 +16,10 @@ RUN apk add --update tar gnupg bash openssl && rm -rf /var/cache/apk/*
 
 # Download the whole repo as an archive
 RUN mkdir -p $LEIN_INSTALL \
-  && wget -q https://github.com/technomancy/leiningen/archive/$LEIN_VERSION.tar.gz \
-  && echo "Comparing archive checksum ..." \
-  && echo "6fe90ca265f43f574f665a9146a443574280928e *$LEIN_VERSION.tar.gz" | sha1sum -c - \
-  && mkdir ./leiningen \
-  && tar -xzf $LEIN_VERSION.tar.gz  -C ./leiningen/ --strip-components=1 \
-  && mv leiningen/bin/lein-pkg $LEIN_INSTALL/lein \
-  && rm -rf $LEIN_VERSION.tar.gz ./leiningen \
+  && wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg \
+  && echo "Comparing lein-pkg checksum ..." \
+  && echo "2efff6ca3a77d66d041d705abf7a92cb7efafabb *lein-pkg" | sha1sum -c - \
+  && mv lein-pkg $LEIN_INSTALL/lein \
   && chmod 0755 $LEIN_INSTALL/lein \
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \

--- a/alpine/lein/Dockerfile
+++ b/alpine/lein/Dockerfile
@@ -7,7 +7,7 @@
 FROM openjdk:8-alpine
 MAINTAINER Wes Morgan <wesmorgan@icloud.com>
 
-ENV LEIN_VERSION=2.7.1
+ENV LEIN_VERSION=2.8.0
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -18,24 +18,17 @@ RUN apk add --update tar gnupg bash openssl && rm -rf /var/cache/apk/*
 RUN mkdir -p $LEIN_INSTALL \
   && wget -q https://github.com/technomancy/leiningen/archive/$LEIN_VERSION.tar.gz \
   && echo "Comparing archive checksum ..." \
-  && echo "876221e884780c865c2ce5c9aa5675a7cae9f215 *$LEIN_VERSION.tar.gz" | sha1sum -c - \
-
+  && echo "6fe90ca265f43f574f665a9146a443574280928e *$LEIN_VERSION.tar.gz" | sha1sum -c - \
   && mkdir ./leiningen \
   && tar -xzf $LEIN_VERSION.tar.gz  -C ./leiningen/ --strip-components=1 \
   && mv leiningen/bin/lein-pkg $LEIN_INSTALL/lein \
   && rm -rf $LEIN_VERSION.tar.gz ./leiningen \
-
   && chmod 0755 $LEIN_INSTALL/lein \
-
-# Download and verify Lein stand-alone jar
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \
-
-  && gpg --keyserver pool.sks-keyservers.net --recv-key 2E708FB2FCECA07FF8184E275A92E04305696D78 \
+  && gpg --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 \
   && echo "Verifying Jar file signature ..." \
   && gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc \
-
-# Put the jar where lein script expects
   && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
   && mkdir -p /usr/share/java \
   && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar

--- a/debian/lein/Dockerfile
+++ b/debian/lein/Dockerfile
@@ -14,13 +14,10 @@ WORKDIR /tmp
 
 # Download the whole repo as an archive
 RUN mkdir -p $LEIN_INSTALL \
-  && wget -q https://github.com/technomancy/leiningen/archive/$LEIN_VERSION.tar.gz \
-  && echo "Comparing archive checksum ..." \
-  && echo "6fe90ca265f43f574f665a9146a443574280928e *$LEIN_VERSION.tar.gz" | sha1sum -c - \
-  && mkdir ./leiningen \
-  && tar -xzf $LEIN_VERSION.tar.gz  -C ./leiningen/ --strip-components=1 \
-  && mv leiningen/bin/lein-pkg $LEIN_INSTALL/lein \
-  && rm -rf $LEIN_VERSION.tar.gz ./leiningen \
+  && wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg \
+  && echo "Comparing lein-pkg checksum ..." \
+  && echo "2efff6ca3a77d66d041d705abf7a92cb7efafabb *lein-pkg" | sha1sum -c - \
+  && mv lein-pkg $LEIN_INSTALL/lein \
   && chmod 0755 $LEIN_INSTALL/lein \
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \

--- a/debian/lein/Dockerfile
+++ b/debian/lein/Dockerfile
@@ -7,7 +7,7 @@
 FROM openjdk:8
 MAINTAINER Paul Lam <paul@quantisan.com>
 
-ENV LEIN_VERSION=2.7.1
+ENV LEIN_VERSION=2.8.0
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -16,24 +16,17 @@ WORKDIR /tmp
 RUN mkdir -p $LEIN_INSTALL \
   && wget -q https://github.com/technomancy/leiningen/archive/$LEIN_VERSION.tar.gz \
   && echo "Comparing archive checksum ..." \
-  && echo "876221e884780c865c2ce5c9aa5675a7cae9f215 *$LEIN_VERSION.tar.gz" | sha1sum -c - \
-
+  && echo "6fe90ca265f43f574f665a9146a443574280928e *$LEIN_VERSION.tar.gz" | sha1sum -c - \
   && mkdir ./leiningen \
   && tar -xzf $LEIN_VERSION.tar.gz  -C ./leiningen/ --strip-components=1 \
   && mv leiningen/bin/lein-pkg $LEIN_INSTALL/lein \
   && rm -rf $LEIN_VERSION.tar.gz ./leiningen \
-
   && chmod 0755 $LEIN_INSTALL/lein \
-
-# Download and verify Lein stand-alone jar
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
   && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \
-
-  && gpg --keyserver pool.sks-keyservers.net --recv-key 2E708FB2FCECA07FF8184E275A92E04305696D78 \
+  && gpg --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 \
   && echo "Verifying Jar file signature ..." \
   && gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc \
-
-# Put the jar where lein script expects
   && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
   && mkdir -p /usr/share/java \
   && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar


### PR DESCRIPTION
I also removed the blank lines from the big `RUN` in the Dockerfiles because the latest version of Docker is warning that those will soon generate a build error.