### PR TITLE
Build in dirs for compatibility w/ official images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cpcache/
-/Dockerfile.*
+/target/*
+!/target/.gitkeep


### PR DESCRIPTION
Some of the recently-merged changes broke our compatibility with the upstream build system. They want a `Directory` that contains both a `Dockerfile` and the build root (which can just be empty for our needs).

So I've refactored things to work that way again with the new Clojure build system.