### PR TITLE
Add images for alpine openjdk 14

### DIFF
--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -27,7 +27,7 @@
   (s/map-of keyword? ::non-blank-string))
 
 (def base-images
-  #{"openjdk:8" "openjdk:11"})
+  #{"openjdk:8" "openjdk:11" "openjdk:14"})
 
 (def distros
   #{"debian" "alpine"})
@@ -39,7 +39,9 @@
 
 (def exclusions ; don't build these for whatever reason(s)
   #{{:base-image "openjdk:11"
-     :distro     "alpine"}})
+     :distro     "alpine"}
+    {:base-image "openjdk:14"
+     :distro     "debian"}})
 
 (def maintainers
   {:paul "Paul Lam <paul@quantisan.com>"

--- a/target/openjdk-14/alpine/boot/Dockerfile
+++ b/target/openjdk-14/alpine/boot/Dockerfile
@@ -1,0 +1,26 @@
+FROM openjdk:14-alpine
+LABEL maintainer="Wes Morgan <wesmorgan@icloud.com>"
+
+ENV BOOT_VERSION=2.8.2
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+RUN apk add --update --no-cache bash openssl
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN mkdir -p $BOOT_INSTALL \
+  && wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh \
+  && echo "Comparing installer checksum..." \
+  && echo "f717ef381f2863a4cad47bf0dcc61e923b3d2afb *boot.sh" | sha1sum -c - \
+  && mv boot.sh $BOOT_INSTALL/boot \
+  && chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-14/alpine/lein/Dockerfile
+++ b/target/openjdk-14/alpine/lein/Dockerfile
@@ -1,0 +1,35 @@
+FROM openjdk:14-alpine
+LABEL maintainer="Wes Morgan <wesmorgan@icloud.com>"
+
+ENV LEIN_VERSION=2.9.1
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+RUN apk add --update --no-cache tar gnupg bash openssl
+
+# Download the whole repo as an archive
+RUN mkdir -p $LEIN_INSTALL \
+  && wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg \
+  && echo "Comparing lein-pkg checksum ..." \
+  && sha1sum lein-pkg \
+  && echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - \
+  && mv lein-pkg $LEIN_INSTALL/lein \
+  && chmod 0755 $LEIN_INSTALL/lein \
+  && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
+  && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \
+  && gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 \
+  && echo "Verifying Jar file signature ..." \
+  && gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc \
+  && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
+  && mkdir -p /usr/share/java \
+  && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-14/alpine/tools-deps/Dockerfile
+++ b/target/openjdk-14/alpine/tools-deps/Dockerfile
@@ -1,0 +1,18 @@
+FROM openjdk:14-alpine
+LABEL maintainer="Kirill Chernyshov <delaguardo@gmail.com>"
+
+ENV CLOJURE_VERSION=1.10.0.442
+
+WORKDIR /tmp
+
+RUN apk add --update --no-cache bash curl
+
+RUN wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh \
+    && chmod +x linux-install-$CLOJURE_VERSION.sh \
+    && ./linux-install-$CLOJURE_VERSION.sh
+
+RUN clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+CMD ["sh", "-c", "sleep 1 && exec clj"]


### PR DESCRIPTION
14 is the only alpine tag listed on https://github.com/docker-library/docs/blob/master/openjdk/README.md#supported-tags-and-respective-dockerfile-links
but it's nice to have something newer than 8.

What do you think?  Are there things to consider before deciding whether or not to publish this?