### PR TITLE
Install all build tools in latest tag

### DIFF
--- a/src/docker_clojure/dockerfile/boot.clj
+++ b/src/docker_clojure/dockerfile/boot.clj
@@ -35,7 +35,7 @@
 
     nil))
 
-(defn contents [{:keys [build-tool-version] :as variant}]
+(defn install [{:keys [build-tool-version] :as variant}]
   (let [install-dep-cmds (install-deps variant)
         uninstall-dep-cmds (uninstall-build-deps variant)]
     (-> [(format "ENV BOOT_VERSION=%s" build-tool-version)
@@ -61,8 +61,12 @@
           "ENV PATH=$PATH:$BOOT_INSTALL"
           "ENV BOOT_AS_ROOT=yes"
           ""
-          "RUN boot"
-          ""
-          "CMD [\"boot\", \"repl\"]"])
+          "RUN boot"])
 
         (->> (remove nil?)))))
+
+(def command
+  ["CMD [\"boot\", \"repl\"]"])
+
+(defn contents [variant]
+  (concat (install variant) [""] command))

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -3,9 +3,9 @@
             [docker-clojure.dockerfile.shared :refer :all]))
 
 (def distro-deps
-  {"slim-buster" {:build   #{"wget" "gnupg"}
+  {"slim-buster" {:build   #{"wget"}
                   :runtime #{}}
-   "alpine"      {:build   #{"tar" "gnupg" "openssl"}
+   "alpine"      {:build   #{"tar" "openssl"}
                   :runtime #{"bash"}}})
 
 (defn install-deps [{:keys [distro]}]
@@ -54,11 +54,6 @@
           "mv lein-pkg $LEIN_INSTALL/lein"
           "chmod 0755 $LEIN_INSTALL/lein"
           "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"
-          "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc"
-          "gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18"
-          "echo \"Verifying Jar file signature ...\""
-          "gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc"
-          "rm leiningen-$LEIN_VERSION-standalone.zip.asc"
           "mkdir -p /usr/share/java"
           "mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar"]
          (empty? uninstall-dep-cmds))

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -34,7 +34,7 @@
 
     nil))
 
-(defn contents [{:keys [build-tool-version] :as variant}]
+(defn install [{:keys [build-tool-version] :as variant}]
   (let [install-dep-cmds (install-deps variant)
         uninstall-dep-cmds (uninstall-build-deps variant)]
     (-> [(format "ENV LEIN_VERSION=%s" build-tool-version)
@@ -65,8 +65,12 @@
           ""
           "# Install clojure 1.10.1 so users don't have to download it every time"
           "RUN echo '(defproject dummy \"\" :dependencies [[org.clojure/clojure \"1.10.1\"]])' > project.clj \\"
-          "  && lein deps && rm project.clj"
-          ""
-          "CMD [\"lein\", \"repl\"]"])
+          "  && lein deps && rm project.clj"])
 
         (->> (remove nil?)))))
+
+(def command
+  ["CMD [\"lein\", \"repl\"]"])
+
+(defn contents [variant]
+  (concat (install variant) [""] command))

--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -34,7 +34,7 @@
 
     nil))
 
-(defn contents [{:keys [build-tool-version] :as variant}]
+(defn install [{:keys [build-tool-version] :as variant}]
   (let [install-dep-cmds (install-deps variant)
         uninstall-dep-cmds (uninstall-build-deps variant)]
     (-> [(format "ENV CLOJURE_VERSION=%s" build-tool-version)
@@ -49,12 +49,14 @@
           "./linux-install-$CLOJURE_VERSION.sh"
           "clojure -e \"(clojure-version)\""] (empty? uninstall-dep-cmds))
         (concat-commands uninstall-dep-cmds :end)
-        (concat
-         [""
-          "# Docker bug makes rlwrap crash w/o short sleep first"
-          "# Bug: https://github.com/moby/moby/issues/28009"
-          "# As of 2019-10-2 this bug still exists, despite that issue being closed"
-          "CMD [\"sh\", \"-c\", \"sleep 1 && exec clj\"]"])
 
         (->> (remove nil?)))))
 
+(def command
+  ["# Docker bug makes rlwrap crash w/o short sleep first"
+   "# Bug: https://github.com/moby/moby/issues/28009"
+   "# As of 2019-10-2 this bug still exists, despite that issue being closed"
+   "CMD [\"sh\", \"-c\", \"sleep 1 && exec clj\"]"])
+
+(defn contents [variant]
+  (concat (install variant) [""] command))

--- a/target/openjdk-11-slim-buster/lein/Dockerfile
+++ b/target/openjdk-11-slim-buster/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
@@ -18,14 +18,9 @@ echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 && \
-echo "Verifying Jar file signature ..." && \
-gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apt-get remove -y --purge gnupg wget
+apt-get remove -y --purge wget
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-11-stretch/latest/Dockerfile
+++ b/target/openjdk-11-stretch/latest/Dockerfile
@@ -1,0 +1,62 @@
+FROM openjdk:11-stretch
+
+### INSTALL BOOT ###
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+echo "f717ef381f2863a4cad47bf0dcc61e923b3d2afb *boot.sh" | sha1sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+### INSTALL LEIN ###
+ENV LEIN_VERSION=2.9.1
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha1sum lein-pkg && \
+echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+### INSTALL TOOLS-DEPS ###
+ENV CLOJURE_VERSION=1.10.1.502
+
+WORKDIR /tmp
+
+RUN \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+CMD ["lein", "repl"]

--- a/target/openjdk-11-stretch/lein/Dockerfile
+++ b/target/openjdk-11-stretch/lein/Dockerfile
@@ -15,11 +15,6 @@ echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 && \
-echo "Verifying Jar file signature ..." && \
-gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 

--- a/target/openjdk-13-buster/lein/Dockerfile
+++ b/target/openjdk-13-buster/lein/Dockerfile
@@ -15,11 +15,6 @@ echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 && \
-echo "Verifying Jar file signature ..." && \
-gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 

--- a/target/openjdk-13-slim-buster/lein/Dockerfile
+++ b/target/openjdk-13-slim-buster/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
@@ -18,14 +18,9 @@ echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 && \
-echo "Verifying Jar file signature ..." && \
-gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apt-get remove -y --purge gnupg wget
+apt-get remove -y --purge wget
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-14-alpine/lein/Dockerfile
+++ b/target/openjdk-14-alpine/lein/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 
 # Download the whole repo as an archive
 RUN \
-apk add --update --no-cache bash tar openssl gnupg && \
+apk add --update --no-cache bash tar openssl && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
@@ -16,14 +16,9 @@ echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 && \
-echo "Verifying Jar file signature ..." && \
-gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apk del tar openssl gnupg
+apk del tar openssl
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-14-buster/lein/Dockerfile
+++ b/target/openjdk-14-buster/lein/Dockerfile
@@ -15,11 +15,6 @@ echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 && \
-echo "Verifying Jar file signature ..." && \
-gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 

--- a/target/openjdk-14-slim-buster/lein/Dockerfile
+++ b/target/openjdk-14-slim-buster/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
@@ -18,14 +18,9 @@ echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 && \
-echo "Verifying Jar file signature ..." && \
-gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apt-get remove -y --purge gnupg wget
+apt-get remove -y --purge wget
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-8-slim-buster/lein/Dockerfile
+++ b/target/openjdk-8-slim-buster/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
@@ -18,14 +18,9 @@ echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 && \
-echo "Verifying Jar file signature ..." && \
-gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apt-get remove -y --purge gnupg wget
+apt-get remove -y --purge wget
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-8-stretch/lein/Dockerfile
+++ b/target/openjdk-8-stretch/lein/Dockerfile
@@ -15,11 +15,6 @@ echo "93be2c23ab4ff2fc4fcf531d7510ca4069b8d24a *lein-pkg" | sha1sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver pool.sks-keyservers.net --recv-key 2B72BF956E23DE5E830D50F6002AF007D1A7CC18 && \
-echo "Verifying Jar file signature ..." && \
-gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 


### PR DESCRIPTION
An idea coming out of discussion on #80. Implementing this consisted mostly of splitting up the install commands from the runtime commands (literally the `CMD` lines) in the generated Dockerfiles.

I also removed the lein GPG verification because it is just horrendously unreliable, and I have had no success improving it. With the number of image variants we're building nowadays, I can't get them to all successfully build because one or more will inevitably fail at this step. So unfortunately I think we need to drop it.