### PR TITLE
Update leiningen to 2.9.3

### DIFF
--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -33,19 +33,17 @@
 
 (def base-image "openjdk")
 
-(def jdk-versions #{8 11 13 14})
+(def jdk-versions #{8 11 13 14 15})
 
 ;; The default JDK version to use for tags that don't specify one; usually the latest LTS release
 (def default-jdk-version 11)
 
 (def distros
-  #{"stretch" "buster" "slim-buster" "alpine"})
+  #{"buster" "slim-buster" "alpine"})
 
 ;; The default distro to use for tags that don't specify one, keyed by jdk-version.
 (def default-distros
-  {:default "slim-buster"
-   8        "stretch"
-   11       "stretch"})
+  {:default "slim-buster"})
 
 (def build-tools
   {"lein"       "2.9.2"
@@ -59,14 +57,8 @@
      :distro      "alpine"}
     {:jdk-version 13
      :distro      "alpine"}
-    {:jdk-version 8
-     :distro      "buster"}
-    {:jdk-version 11
-     :distro      "buster"}
     {:jdk-version 14
-     :distro      "stretch"}
-    {:jdk-version 13
-     :distro      "stretch"}})
+     :distro      "alpine"}})
 
 (def maintainers
   "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>")

--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -33,7 +33,7 @@
 
 (def base-image "openjdk")
 
-(def jdk-versions #{8 11 13 14 15})
+(def jdk-versions #{8 11 14 15})
 
 ;; The default JDK version to use for tags that don't specify one; usually the latest LTS release
 (def default-jdk-version 11)
@@ -54,8 +54,6 @@
   #{{:jdk-version 8
      :distro      "alpine"}
     {:jdk-version 11
-     :distro      "alpine"}
-    {:jdk-version 13
      :distro      "alpine"}
     {:jdk-version 14
      :distro      "alpine"}})

--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -46,7 +46,7 @@
   {:default "slim-buster"})
 
 (def build-tools
-  {"lein"       "2.9.2"
+  {"lein"       "2.9.3"
    "boot"       "2.8.3"
    "tools-deps" "1.10.1.536"})
 

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -50,7 +50,7 @@
           "wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg"
           "echo \"Comparing lein-pkg checksum ...\""
           "sha256sum lein-pkg"
-          "echo \"36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg\" | sha256sum -c -"
+          "echo \"42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg\" | sha256sum -c -"
           "mv lein-pkg $LEIN_INSTALL/lein"
           "chmod 0755 $LEIN_INSTALL/lein"
           "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"

--- a/target/openjdk-11-buster/boot/Dockerfile
+++ b/target/openjdk-11-buster/boot/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:11-buster
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-11-buster/lein/Dockerfile
+++ b/target/openjdk-11-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-buster
 
-ENV LEIN_VERSION=2.9.2
+ENV LEIN_VERSION=2.9.3
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -11,7 +11,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-11-buster/lein/Dockerfile
+++ b/target/openjdk-11-buster/lein/Dockerfile
@@ -1,0 +1,28 @@
+FROM openjdk:11-buster
+
+ENV LEIN_VERSION=2.9.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-11-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-buster/tools-deps/Dockerfile
@@ -1,0 +1,18 @@
+FROM openjdk:11-buster
+
+ENV CLOJURE_VERSION=1.10.1.536
+
+WORKDIR /tmp
+
+RUN \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "83b824091723afe8e0f4e958bf74a2f7cd4c4caddd34e31af6ef1a4323c45ff1 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-11-slim-buster/latest/Dockerfile
+++ b/target/openjdk-11-slim-buster/latest/Dockerfile
@@ -29,7 +29,7 @@ ENV BOOT_AS_ROOT=yes
 RUN boot
 
 ### INSTALL LEIN ###
-ENV LEIN_VERSION=2.9.2
+ENV LEIN_VERSION=2.9.3
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -43,7 +43,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-11-slim-buster/latest/Dockerfile
+++ b/target/openjdk-11-slim-buster/latest/Dockerfile
@@ -1,0 +1,78 @@
+FROM openjdk:11-slim-buster
+
+### INSTALL BOOT ###
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get remove -y --purge wget && \
+apt-get autoremove -y
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+### INSTALL LEIN ###
+ENV LEIN_VERSION=2.9.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get remove -y --purge wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+### INSTALL TOOLS-DEPS ###
+ENV CLOJURE_VERSION=1.10.1.536
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "83b824091723afe8e0f4e958bf74a2f7cd4c4caddd34e31af6ef1a4323c45ff1 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get remove -y --purge curl wget
+
+CMD ["lein", "repl"]

--- a/target/openjdk-11-slim-buster/lein/Dockerfile
+++ b/target/openjdk-11-slim-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim-buster
 
-ENV LEIN_VERSION=2.9.2
+ENV LEIN_VERSION=2.9.3
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-14-buster/lein/Dockerfile
+++ b/target/openjdk-14-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:14-buster
 
-ENV LEIN_VERSION=2.9.2
+ENV LEIN_VERSION=2.9.3
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -11,7 +11,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-14-slim-buster/lein/Dockerfile
+++ b/target/openjdk-14-slim-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:14-slim-buster
 
-ENV LEIN_VERSION=2.9.2
+ENV LEIN_VERSION=2.9.3
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-15-alpine/boot/Dockerfile
+++ b/target/openjdk-15-alpine/boot/Dockerfile
@@ -1,0 +1,27 @@
+FROM openjdk:15-alpine
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apk add --update --no-cache bash openssl && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apk del openssl
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-15-alpine/lein/Dockerfile
+++ b/target/openjdk-15-alpine/lein/Dockerfile
@@ -1,0 +1,30 @@
+FROM openjdk:15-alpine
+
+ENV LEIN_VERSION=2.9.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apk add --update --no-cache bash tar openssl && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apk del tar openssl
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-15-alpine/lein/Dockerfile
+++ b/target/openjdk-15-alpine/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:15-alpine
 
-ENV LEIN_VERSION=2.9.2
+ENV LEIN_VERSION=2.9.3
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -12,7 +12,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-15-alpine/tools-deps/Dockerfile
+++ b/target/openjdk-15-alpine/tools-deps/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:15-alpine
+
+ENV CLOJURE_VERSION=1.10.1.536
+
+WORKDIR /tmp
+
+RUN \
+apk add --update --no-cache curl bash make && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "83b824091723afe8e0f4e958bf74a2f7cd4c4caddd34e31af6ef1a4323c45ff1 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apk del curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-15-buster/boot/Dockerfile
+++ b/target/openjdk-15-buster/boot/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:15-buster
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-15-buster/lein/Dockerfile
+++ b/target/openjdk-15-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:15-buster
 
-ENV LEIN_VERSION=2.9.2
+ENV LEIN_VERSION=2.9.3
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -11,7 +11,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-15-buster/lein/Dockerfile
+++ b/target/openjdk-15-buster/lein/Dockerfile
@@ -1,0 +1,28 @@
+FROM openjdk:15-buster
+
+ENV LEIN_VERSION=2.9.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-15-buster/tools-deps/Dockerfile
+++ b/target/openjdk-15-buster/tools-deps/Dockerfile
@@ -1,0 +1,18 @@
+FROM openjdk:15-buster
+
+ENV CLOJURE_VERSION=1.10.1.536
+
+WORKDIR /tmp
+
+RUN \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "83b824091723afe8e0f4e958bf74a2f7cd4c4caddd34e31af6ef1a4323c45ff1 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-15-slim-buster/boot/Dockerfile
+++ b/target/openjdk-15-slim-buster/boot/Dockerfile
@@ -1,0 +1,30 @@
+FROM openjdk:15-slim-buster
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get remove -y --purge wget && \
+apt-get autoremove -y
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-15-slim-buster/lein/Dockerfile
+++ b/target/openjdk-15-slim-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:15-slim-buster
 
-ENV LEIN_VERSION=2.9.2
+ENV LEIN_VERSION=2.9.3
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-15-slim-buster/lein/Dockerfile
+++ b/target/openjdk-15-slim-buster/lein/Dockerfile
@@ -1,0 +1,32 @@
+FROM openjdk:15-slim-buster
+
+ENV LEIN_VERSION=2.9.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get remove -y --purge wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-15-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-15-slim-buster/tools-deps/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:15-slim-buster
+
+ENV CLOJURE_VERSION=1.10.1.536
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "83b824091723afe8e0f4e958bf74a2f7cd4c4caddd34e31af6ef1a4323c45ff1 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get remove -y --purge curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-8-buster/boot/Dockerfile
+++ b/target/openjdk-8-buster/boot/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:8-buster
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-8-buster/lein/Dockerfile
+++ b/target/openjdk-8-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-buster
 
-ENV LEIN_VERSION=2.9.2
+ENV LEIN_VERSION=2.9.3
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -11,7 +11,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-8-buster/lein/Dockerfile
+++ b/target/openjdk-8-buster/lein/Dockerfile
@@ -1,0 +1,28 @@
+FROM openjdk:8-buster
+
+ENV LEIN_VERSION=2.9.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-8-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-buster/tools-deps/Dockerfile
@@ -1,0 +1,18 @@
+FROM openjdk:8-buster
+
+ENV CLOJURE_VERSION=1.10.1.536
+
+WORKDIR /tmp
+
+RUN \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "83b824091723afe8e0f4e958bf74a2f7cd4c4caddd34e31af6ef1a4323c45ff1 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-8-slim-buster/lein/Dockerfile
+++ b/target/openjdk-8-slim-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim-buster
 
-ENV LEIN_VERSION=2.9.2
+ENV LEIN_VERSION=2.9.3
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "36f879a26442648ec31cfa990487cbd337a5ff3b374433a6e5bf393d06597602 *lein-pkg" | sha256sum -c - && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/test/docker_clojure/core_test.clj
+++ b/test/docker_clojure/core_test.clj
@@ -4,85 +4,92 @@
             [clojure.string :as str]))
 
 (deftest default-distro-test
-  (testing "jdk-version 8 gets stretch"
-    (is (= "stretch" (default-distro 8))))
-  (testing "jdk-version 11 gets stretch"
-    (is (= "stretch" (default-distro 11))))
+  (testing "jdk-version 8 gets slim-buster"
+    (is (= "slim-buster" (default-distro 8))))
+  (testing "jdk-version 11 gets slim-buster"
+    (is (= "slim-buster" (default-distro 11))))
   (testing "other versions get slim-buster"
     (is (= "slim-buster" (default-distro 12)))
     (is (= "slim-buster" (default-distro 13)))
-    (is (= "slim-buster" (default-distro 14)))))
+    (is (= "slim-buster" (default-distro 14)))
+    (is (= "slim-buster" (default-distro 15)))))
 
 (deftest image-variants-test
   (testing "generates the expected set of variants"
-    (let [variants (image-variants #{8 11 13 14}
-                                   #{"stretch" "slim-buster" "alpine"}
+    (let [variants (image-variants #{8 11 13 14 15}
+                                   #{"buster" "slim-buster" "alpine"}
                                    {"lein"       "2.9.1"
                                     "boot"       "2.8.3"
                                     "tools-deps" "1.10.1.478"})]
-      (are [v] (contains? variants v)
+      ;; filter is to make failure output a little more humane
+      (are [v] (contains? (->> variants
+                               (filter #(and (= (:jdk-version %) (:jdk-version v))
+                                             (= (:distro %)      (:distro v))
+                                             (= (:build-tool %)  (:build-tool v))))
+                               set)
+                          v)
             {:jdk-version 11, :distro "slim-buster", :build-tool "lein"
                  :base-image "openjdk:11-slim-buster"
                  :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                 :docker-tag "lein-2.9.1-slim-buster", :build-tool-version "2.9.1"}
+                 :docker-tag "lein-2.9.1", :build-tool-version "2.9.1"}
             {:jdk-version 11, :distro "slim-buster", :build-tool "boot"
                 :base-image "openjdk:11-slim-buster"
                 :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                :docker-tag "boot-2.8.3-slim-buster", :build-tool-version "2.8.3"}
+                :docker-tag "boot-2.8.3", :build-tool-version "2.8.3"}
             {:jdk-version 11, :distro "slim-buster"
                 :base-image "openjdk:11-slim-buster"
                 :build-tool "tools-deps"
                 :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                :docker-tag "tools-deps-1.10.1.478-slim-buster"
+                :docker-tag "tools-deps-1.10.1.478"
                 :build-tool-version "1.10.1.478"}
-            {:jdk-version 11, :distro "stretch", :build-tool "lein"
-                :base-image "openjdk:11-stretch"
+            {:jdk-version 11, :distro "buster", :build-tool "lein"
+                :base-image "openjdk:11-buster"
                 :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                :docker-tag "lein-2.9.1", :build-tool-version "2.9.1"}
-            {:jdk-version 11, :distro "stretch", :build-tool "boot"
-                :base-image "openjdk:11-stretch"
+                :docker-tag "lein-2.9.1-buster", :build-tool-version "2.9.1"}
+            {:jdk-version 11, :distro "buster", :build-tool "boot"
+                :base-image "openjdk:11-buster"
                 :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                :docker-tag "boot-2.8.3", :build-tool-version "2.8.3"}
-            {:jdk-version 11, :distro "stretch"
-             :base-image "openjdk:11-stretch"
+                :docker-tag "boot-2.8.3-buster", :build-tool-version "2.8.3"}
+            {:jdk-version 11, :distro "buster"
+             :base-image "openjdk:11-buster"
              :build-tool "tools-deps"
              :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "tools-deps-1.10.1.478"
+             :docker-tag "tools-deps-1.10.1.478-buster"
              :build-tool-version "1.10.1.478"}
             {:jdk-version 8, :distro "slim-buster", :build-tool "lein"
              :base-image "openjdk:8-slim-buster"
              :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-8-lein-2.9.1-slim-buster", :build-tool-version "2.9.1"}
+             :docker-tag "openjdk-8-lein-2.9.1", :build-tool-version "2.9.1"}
             {:jdk-version 8, :distro "slim-buster", :build-tool "boot"
              :base-image "openjdk:8-slim-buster"
              :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-8-boot-2.8.3-slim-buster", :build-tool-version "2.8.3"}
+             :docker-tag "openjdk-8-boot-2.8.3", :build-tool-version "2.8.3"}
             {:jdk-version 8, :distro "slim-buster"
              :build-tool "tools-deps"
              :base-image "openjdk:8-slim-buster"
              :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-8-tools-deps-1.10.1.478-slim-buster"
+             :docker-tag "openjdk-8-tools-deps-1.10.1.478"
              :build-tool-version "1.10.1.478"}
             {:jdk-version 13, :distro "slim-buster", :build-tool "lein"
              :base-image "openjdk:13-slim-buster"
              :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
              :docker-tag "openjdk-13-lein-2.9.1"
              :build-tool-version "2.9.1"}
-            {:jdk-version 14, :distro "alpine", :build-tool "lein"
-             :base-image "openjdk:14-alpine"
+            {:jdk-version 15, :distro "alpine", :build-tool "lein"
+             :base-image "openjdk:15-alpine"
              :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-14-lein-2.9.1-alpine"
+             :docker-tag "openjdk-15-lein-2.9.1-alpine"
              :build-tool-version "2.9.1"}
-            {:jdk-version 14, :distro "alpine", :build-tool "boot"
-             :base-image "openjdk:14-alpine"
+            {:jdk-version 15, :distro "alpine", :build-tool "boot"
+             :base-image "openjdk:15-alpine"
              :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-14-boot-2.8.3-alpine"
+             :docker-tag "openjdk-15-boot-2.8.3-alpine"
              :build-tool-version "2.8.3"}
-            {:jdk-version 14, :distro "alpine"
-             :base-image "openjdk:14-alpine"
+            {:jdk-version 15, :distro "alpine"
+             :base-image "openjdk:15-alpine"
              :build-tool "tools-deps"
              :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-14-tools-deps-1.10.1.478-alpine"
+             :docker-tag "openjdk-15-tools-deps-1.10.1.478-alpine"
              :build-tool-version "1.10.1.478"}))))
 
 (deftest variant-map-test

--- a/test/docker_clojure/core_test.clj
+++ b/test/docker_clojure/core_test.clj
@@ -10,13 +10,12 @@
     (is (= "slim-buster" (default-distro 11))))
   (testing "other versions get slim-buster"
     (is (= "slim-buster" (default-distro 12)))
-    (is (= "slim-buster" (default-distro 13)))
     (is (= "slim-buster" (default-distro 14)))
     (is (= "slim-buster" (default-distro 15)))))
 
 (deftest image-variants-test
   (testing "generates the expected set of variants"
-    (let [variants (image-variants #{8 11 13 14 15}
+    (let [variants (image-variants #{8 11 14 15}
                                    #{"buster" "slim-buster" "alpine"}
                                    {"lein"       "2.9.1"
                                     "boot"       "2.8.3"
@@ -70,10 +69,10 @@
              :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
              :docker-tag "openjdk-8-tools-deps-1.10.1.478"
              :build-tool-version "1.10.1.478"}
-            {:jdk-version 13, :distro "slim-buster", :build-tool "lein"
-             :base-image "openjdk:13-slim-buster"
+            {:jdk-version 14, :distro "slim-buster", :build-tool "lein"
+             :base-image "openjdk:14-slim-buster"
              :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-13-lein-2.9.1"
+             :docker-tag "openjdk-14-lein-2.9.1"
              :build-tool-version "2.9.1"}
             {:jdk-version 15, :distro "alpine", :build-tool "lein"
              :base-image "openjdk:15-alpine"
@@ -118,10 +117,10 @@
     (is (not (str/includes? (docker-tag {:jdk-version 11})
                             "openjdk-11"))))
   (testing "non-default version is added as a prefix"
-    (is (str/starts-with? (docker-tag {:jdk-version 13})
-                          "openjdk-13")))
+    (is (str/starts-with? (docker-tag {:jdk-version 14})
+                          "openjdk-14")))
   (testing "default distro is left out"
-    (is (not (str/includes? (docker-tag {:jdk-version 13
+    (is (not (str/includes? (docker-tag {:jdk-version 14
                                          :distro "slim-buster"})
                             "slim-buster"))))
   (testing "alpine is added as a suffix"


### PR DESCRIPTION
This builds on top of #84 (just because I'm lazy) so feel free to review that first. Just updates leiningen to the recently released 2.9.3 version. The relevant commit for this PR is f1c6fc1.