### PR TITLE
Feature: restore PGP sig verification for leiningen

### DIFF
--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -55,7 +55,7 @@
           "chmod 0755 $LEIN_INSTALL/lein"
           "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"
           "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc"
-          "gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org"
+          "gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3"
           "echo \"Verifying file PGP signature...\""
           "gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip"
           "rm leiningen-$LEIN_VERSION-standalone.zip.asc"

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -3,9 +3,9 @@
             [docker-clojure.dockerfile.shared :refer :all]))
 
 (def distro-deps
-  {"slim-buster" {:build   #{"wget"}
+  {"slim-buster" {:build   #{"wget" "gnupg"}
                   :runtime #{}}
-   "alpine"      {:build   #{"tar" "openssl"}
+   "alpine"      {:build   #{"tar" "gnupg" "openssl" "ca-certificates"}
                   :runtime #{"bash"}}})
 
 (defn install-deps [{:keys [distro]}]
@@ -54,6 +54,11 @@
           "mv lein-pkg $LEIN_INSTALL/lein"
           "chmod 0755 $LEIN_INSTALL/lein"
           "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"
+          "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc"
+          "gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org"
+          "echo \"Verifying file PGP signature...\""
+          "gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip"
+          "rm leiningen-$LEIN_VERSION-standalone.zip.asc"
           "mkdir -p /usr/share/java"
           "mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar"]
          (empty? uninstall-dep-cmds))

--- a/target/openjdk-11-buster/lein/Dockerfile
+++ b/target/openjdk-11-buster/lein/Dockerfile
@@ -16,7 +16,7 @@ mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
 echo "Verifying file PGP signature..." && \
 gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
 rm leiningen-$LEIN_VERSION-standalone.zip.asc && \

--- a/target/openjdk-11-buster/lein/Dockerfile
+++ b/target/openjdk-11-buster/lein/Dockerfile
@@ -15,6 +15,11 @@ echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 

--- a/target/openjdk-11-slim-buster/latest/Dockerfile
+++ b/target/openjdk-11-slim-buster/latest/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN \
 apt-get update && \
-apt-get install -y wget && \
+apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
@@ -47,9 +47,14 @@ echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apt-get remove -y --purge wget
+apt-get remove -y --purge gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-11-slim-buster/latest/Dockerfile
+++ b/target/openjdk-11-slim-buster/latest/Dockerfile
@@ -48,7 +48,7 @@ mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
 echo "Verifying file PGP signature..." && \
 gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
 rm leiningen-$LEIN_VERSION-standalone.zip.asc && \

--- a/target/openjdk-11-slim-buster/lein/Dockerfile
+++ b/target/openjdk-11-slim-buster/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN \
 apt-get update && \
-apt-get install -y wget && \
+apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
@@ -18,9 +18,14 @@ echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apt-get remove -y --purge wget
+apt-get remove -y --purge gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-11-slim-buster/lein/Dockerfile
+++ b/target/openjdk-11-slim-buster/lein/Dockerfile
@@ -19,7 +19,7 @@ mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
 echo "Verifying file PGP signature..." && \
 gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
 rm leiningen-$LEIN_VERSION-standalone.zip.asc && \

--- a/target/openjdk-14-buster/lein/Dockerfile
+++ b/target/openjdk-14-buster/lein/Dockerfile
@@ -16,7 +16,7 @@ mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
 echo "Verifying file PGP signature..." && \
 gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
 rm leiningen-$LEIN_VERSION-standalone.zip.asc && \

--- a/target/openjdk-14-buster/lein/Dockerfile
+++ b/target/openjdk-14-buster/lein/Dockerfile
@@ -15,6 +15,11 @@ echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 

--- a/target/openjdk-14-slim-buster/lein/Dockerfile
+++ b/target/openjdk-14-slim-buster/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN \
 apt-get update && \
-apt-get install -y wget && \
+apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
@@ -18,9 +18,14 @@ echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apt-get remove -y --purge wget
+apt-get remove -y --purge gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-14-slim-buster/lein/Dockerfile
+++ b/target/openjdk-14-slim-buster/lein/Dockerfile
@@ -19,7 +19,7 @@ mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
 echo "Verifying file PGP signature..." && \
 gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
 rm leiningen-$LEIN_VERSION-standalone.zip.asc && \

--- a/target/openjdk-15-alpine/lein/Dockerfile
+++ b/target/openjdk-15-alpine/lein/Dockerfile
@@ -17,7 +17,7 @@ mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
 echo "Verifying file PGP signature..." && \
 gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
 rm leiningen-$LEIN_VERSION-standalone.zip.asc && \

--- a/target/openjdk-15-alpine/lein/Dockerfile
+++ b/target/openjdk-15-alpine/lein/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 
 # Download the whole repo as an archive
 RUN \
-apk add --update --no-cache bash tar openssl && \
+apk add --update --no-cache ca-certificates bash tar openssl gnupg && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
@@ -16,9 +16,14 @@ echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apk del tar openssl
+apk del ca-certificates tar openssl gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-15-buster/lein/Dockerfile
+++ b/target/openjdk-15-buster/lein/Dockerfile
@@ -16,7 +16,7 @@ mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
 echo "Verifying file PGP signature..." && \
 gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
 rm leiningen-$LEIN_VERSION-standalone.zip.asc && \

--- a/target/openjdk-15-buster/lein/Dockerfile
+++ b/target/openjdk-15-buster/lein/Dockerfile
@@ -15,6 +15,11 @@ echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 

--- a/target/openjdk-15-slim-buster/lein/Dockerfile
+++ b/target/openjdk-15-slim-buster/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN \
 apt-get update && \
-apt-get install -y wget && \
+apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
@@ -18,9 +18,14 @@ echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apt-get remove -y --purge wget
+apt-get remove -y --purge gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-15-slim-buster/lein/Dockerfile
+++ b/target/openjdk-15-slim-buster/lein/Dockerfile
@@ -19,7 +19,7 @@ mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
 echo "Verifying file PGP signature..." && \
 gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
 rm leiningen-$LEIN_VERSION-standalone.zip.asc && \

--- a/target/openjdk-8-buster/lein/Dockerfile
+++ b/target/openjdk-8-buster/lein/Dockerfile
@@ -16,7 +16,7 @@ mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
 echo "Verifying file PGP signature..." && \
 gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
 rm leiningen-$LEIN_VERSION-standalone.zip.asc && \

--- a/target/openjdk-8-buster/lein/Dockerfile
+++ b/target/openjdk-8-buster/lein/Dockerfile
@@ -15,6 +15,11 @@ echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 

--- a/target/openjdk-8-slim-buster/lein/Dockerfile
+++ b/target/openjdk-8-slim-buster/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN \
 apt-get update && \
-apt-get install -y wget && \
+apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
@@ -18,9 +18,14 @@ echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
 mkdir -p /usr/share/java && \
 mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
-apt-get remove -y --purge wget
+apt-get remove -y --purge gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1

--- a/target/openjdk-8-slim-buster/lein/Dockerfile
+++ b/target/openjdk-8-slim-buster/lein/Dockerfile
@@ -19,7 +19,7 @@ mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --auto-key-locate keyserver --keyserver keys.openpgp.org --locate-keys phil@hagelb.org && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
 echo "Verifying file PGP signature..." && \
 gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
 rm leiningen-$LEIN_VERSION-standalone.zip.asc && \


### PR DESCRIPTION
Now that technomancy has uploaded his key to keys.openpgp.org (thanks again!), use that to more reliably retrieve the key and verify the leiningen download.