### PR TITLE
Add openjdk 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,21 @@
 
 This is the repository for the [official Docker image for Clojure](https://registry.hub.docker.com/_/clojure/).
 It is automatically pulled and built by Stackbrew into the Docker registry.
-This image runs on OpenJDK 8 and includes [Leiningen](http://leiningen.org), [boot](http://boot-clj.com) or [tools-deps](https://clojure.org/reference/deps_and_cli) (see below for tags and building instructions).
+This image runs on OpenJDK 8, 11, 14, 15, and 16 and includes [Leiningen](http://leiningen.org),
+[boot](http://boot-clj.com), and/or [tools-deps](https://clojure.org/reference/deps_and_cli)
+(see below for tags and building instructions).
 
 ## Leiningen vs. boot vs. tools-deps
 
-The version tags on these images look like `lein-N.N.N(-distro)`, `boot-N.N.N(-distro)` and `tools-deps(-distro)`.
+The version tags on these images look like `(openjdk-major-version-)lein-N.N.N(-distro)`,
+`(openjdk-major-version-)boot-N.N.N(-distro)`, and `(openjdk-major-version-)tools-deps(-distro)`.
 These refer to which version of leiningen, boot, or tools-deps is packaged in the image (because they can then install
-and use any version of Clojure at runtime). The default `latest` (or `lein`, `lein-slim-buster`) images will always have
-a recent version of leiningen installed. If you want boot, specify either `clojure:boot` / `clojure:boot-slim-buster` or
-`clojure:boot-N.N.N` / `clojure:boot-N.N.N-slim-buster`. (where `N.N.N` is the version of boot you want installed). If
-you want to use tools-deps, specify either `clojure:tools-deps` or `clojure:tools-deps-alpine`.
+and use any version of Clojure at runtime). The `lein` (or `lein-slim-buster`, `openjdk-14-lein`, etc.)
+images will always have a recent version of leiningen installed. If you want boot, specify either `clojure:boot`,
+`clojure:boot-slim-buster`, or `clojure:boot-N.N.N`, `clojure:boot-N.N.N-slim-buster`,
+`clojure:openjdk-14-boot-N.N.N-slim-buster`, etc. (where `N.N.N` is the version of boot you want installed). If
+you want to use tools-deps, specify either `clojure:tools-deps`, `clojure:tools-deps-slim-buster` or other similar
+variants.
 
 ### Note about the latest tag
 
@@ -32,7 +37,7 @@ the ability to specify which version of Java you'd like via Docker tags:
 JDK 1.8 tools-deps image: `clojure:openjdk-8-tools-deps`
 JDK 11 variant of that image: `clojure:openjdk-11-tools-deps` or `clojure:tool-deps`
 JDK 14 with the latest release of leiningen: `clojure:openjdk-14`
-JDK 15 EA with boot 2.8.3: `clojure:openjdk-15-boot-2.8.3`
+JDK 15 with boot 2.8.3: `clojure:openjdk-15-boot-2.8.3`
 
 ## Linux distro
 
@@ -48,13 +53,13 @@ JDK 15 tools-deps on Alpine: `clojure:openjdk-15-tools-deps-alpine`
 
 ## Alpine Linux
 
-Most of the upstream alpine-based openjdk builds have been deprecated, so we have followed suit. As of 2020-3-20 we
-provide an alpine variant for OpenJDK 15 EA builds, but that's it. And it is likely that that build will go away once
+Most of the upstream alpine-based openjdk builds have been deprecated, so we have followed suit. As of 2020-8-3 we
+provide an alpine variant for OpenJDK 15 and 16 builds, but that's it. And it is likely that that build will go away once
 OpenJDK 15 is released (as has happened with other recent releases).
 
-We recommend migrating to the `slim-buster` variant instead. The older `alpine` images won't go away, but neither will
-they receive security updates, version bumps, etc. We recommend that you cease using them until / unless official
-upstream support resumes.
+For other versions of OpenJDK, we recommend migrating to the `slim-buster` variant instead. The older `alpine` images
+won't go away, but neither will they receive security updates, version bumps, etc. We recommend that you cease using
+them until / unless official upstream support resumes.
 
 ### `clojure:slim-buster`
 

--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -33,7 +33,7 @@
 
 (def base-image "openjdk")
 
-(def jdk-versions #{8 11 14 15})
+(def jdk-versions #{8 11 14 15 16})
 
 ;; The default JDK version to use for tags that don't specify one; usually the latest LTS release
 (def default-jdk-version 11)
@@ -115,9 +115,14 @@
         (assoc :docker-tag (docker-tag base))
         (assoc-if #(nil? (:build-tool-version base)) :build-tool-versions build-tools))))
 
-(defn build-image [{:keys [docker-tag dockerfile build-dir] :as variant}]
+(defn pull-image [image]
+  (sh "docker" "pull" image))
+
+(defn build-image [{:keys [docker-tag dockerfile build-dir base-image] :as variant}]
   (let [image-tag (str "clojure:" docker-tag)
         build-cmd ["docker" "build" "-t" image-tag "-f" dockerfile "."]]
+    (println "Pulling base image" base-image)
+    (pull-image base-image)
     (df/write-file build-dir dockerfile variant)
     (apply println "Running" build-cmd)
     (let [{:keys [out err exit]}

--- a/target/openjdk-16-alpine/boot/Dockerfile
+++ b/target/openjdk-16-alpine/boot/Dockerfile
@@ -1,0 +1,27 @@
+FROM openjdk:16-alpine
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apk add --update --no-cache bash openssl && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apk del openssl
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-16-alpine/lein/Dockerfile
+++ b/target/openjdk-16-alpine/lein/Dockerfile
@@ -1,0 +1,35 @@
+FROM openjdk:16-alpine
+
+ENV LEIN_VERSION=2.9.3
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apk add --update --no-cache ca-certificates bash tar openssl gnupg && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apk del ca-certificates tar openssl gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-16-alpine/tools-deps/Dockerfile
+++ b/target/openjdk-16-alpine/tools-deps/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:16-alpine
+
+ENV CLOJURE_VERSION=1.10.1.619
+
+WORKDIR /tmp
+
+RUN \
+apk add --update --no-cache curl bash make && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "28b1652686426cdf856f83551b8ca01ff949b03bc9a533d270204d6511a8ca9d *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apk del curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-16-buster/boot/Dockerfile
+++ b/target/openjdk-16-buster/boot/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:16-buster
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-16-buster/lein/Dockerfile
+++ b/target/openjdk-16-buster/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:16-buster
+
+ENV LEIN_VERSION=2.9.3
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-16-buster/tools-deps/Dockerfile
+++ b/target/openjdk-16-buster/tools-deps/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:16-buster
+
+ENV CLOJURE_VERSION=1.10.1.619
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y make rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "28b1652686426cdf856f83551b8ca01ff949b03bc9a533d270204d6511a8ca9d *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-16-slim-buster/boot/Dockerfile
+++ b/target/openjdk-16-slim-buster/boot/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:16-slim-buster
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-16-slim-buster/lein/Dockerfile
+++ b/target/openjdk-16-slim-buster/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:16-slim-buster
+
+ENV LEIN_VERSION=2.9.3
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-16-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-16-slim-buster/tools-deps/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:16-slim-buster
+
+ENV CLOJURE_VERSION=1.10.1.619
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "28b1652686426cdf856f83551b8ca01ff949b03bc9a533d270204d6511a8ca9d *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]


### PR DESCRIPTION
New JDK version added. I also gave the README a refresh pass. I also snuck in a small enhancement that pulls upstream images before building on them. I noticed that sometimes builds would be different on my local machine if I had an outdated upstream `openjdk` image already cached. This helps ensure (but does not guarantee) that my local builds are the same as what will get built on the Docker image infrastructure.

After this I'm going to work on reverting our tools-deps images to stable releases only, which I recently learned were a thing: https://groups.google.com/u/2/g/clojure/c/cS8KjpTKBl0