### PR TITLE
Update: tools-deps to 1.10.1.697

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y default-jre-headless rlwrap curl
-        curl -O https://download.clojure.org/install/linux-install-1.10.1.469.sh
-        chmod +x linux-install-1.10.1.469.sh
-        sudo ./linux-install-1.10.1.469.sh
-    - uses: actions/checkout@v1
+        curl -O https://download.clojure.org/install/linux-install-1.10.1.697.sh
+        chmod +x linux-install-1.10.1.697.sh
+        sudo ./linux-install-1.10.1.697.sh
+    - uses: actions/checkout@v2
     - name: Run tests
       run: ./test.sh

--- a/build-images.sh
+++ b/build-images.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-clojure -m docker-clojure.core
+clojure -M -m docker-clojure.core

--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -48,7 +48,7 @@
 (def build-tools
   {"lein"       "2.9.3"
    "boot"       "2.8.3"
-   "tools-deps" "1.10.1.561"})
+   "tools-deps" "1.10.1.697"})
 
 (def exclusions ; don't build these for whatever reason(s)
   #{{:jdk-version 8

--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -26,7 +26,7 @@
         (concat-commands
           ["wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"
            "sha256sum linux-install-$CLOJURE_VERSION.sh"
-           "echo \"7f9e4e7c5a8171db4e4edf5ce78e5b8f453bae641a4c6b7f3dda36c3128d2ff7 *linux-install-$CLOJURE_VERSION.sh\" | sha256sum -c -"
+           "echo \"701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh\" | sha256sum -c -"
            "chmod +x linux-install-$CLOJURE_VERSION.sh"
            "./linux-install-$CLOJURE_VERSION.sh"
            "clojure -e \"(clojure-version)\""] (empty? uninstall-dep-cmds))

--- a/target/openjdk-11-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-buster
 
-ENV CLOJURE_VERSION=1.10.1.561
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7f9e4e7c5a8171db4e4edf5ce78e5b8f453bae641a4c6b7f3dda36c3128d2ff7 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)"

--- a/target/openjdk-11-slim-buster/latest/Dockerfile
+++ b/target/openjdk-11-slim-buster/latest/Dockerfile
@@ -63,7 +63,7 @@ RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' 
   && lein deps && rm project.clj
 
 ### INSTALL TOOLS-DEPS ###
-ENV CLOJURE_VERSION=1.10.1.561
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -73,7 +73,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7f9e4e7c5a8171db4e4edf5ce78e5b8f453bae641a4c6b7f3dda36c3128d2ff7 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-11-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim-buster
 
-ENV CLOJURE_VERSION=1.10.1.561
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7f9e4e7c5a8171db4e4edf5ce78e5b8f453bae641a4c6b7f3dda36c3128d2ff7 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-14-buster/tools-deps/Dockerfile
+++ b/target/openjdk-14-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:14-buster
 
-ENV CLOJURE_VERSION=1.10.1.561
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7f9e4e7c5a8171db4e4edf5ce78e5b8f453bae641a4c6b7f3dda36c3128d2ff7 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)"

--- a/target/openjdk-14-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-14-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:14-slim-buster
 
-ENV CLOJURE_VERSION=1.10.1.561
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7f9e4e7c5a8171db4e4edf5ce78e5b8f453bae641a4c6b7f3dda36c3128d2ff7 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-15-buster/tools-deps/Dockerfile
+++ b/target/openjdk-15-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:15-buster
 
-ENV CLOJURE_VERSION=1.10.1.561
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7f9e4e7c5a8171db4e4edf5ce78e5b8f453bae641a4c6b7f3dda36c3128d2ff7 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)"

--- a/target/openjdk-15-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-15-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:15-slim-buster
 
-ENV CLOJURE_VERSION=1.10.1.561
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7f9e4e7c5a8171db4e4edf5ce78e5b8f453bae641a4c6b7f3dda36c3128d2ff7 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-16-alpine/tools-deps/Dockerfile
+++ b/target/openjdk-16-alpine/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:16-alpine
 
-ENV CLOJURE_VERSION=1.10.1.619
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -8,7 +8,7 @@ RUN \
 apk add --update --no-cache curl bash make && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "28b1652686426cdf856f83551b8ca01ff949b03bc9a533d270204d6511a8ca9d *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-16-buster/tools-deps/Dockerfile
+++ b/target/openjdk-16-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:16-buster
 
-ENV CLOJURE_VERSION=1.10.1.619
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "28b1652686426cdf856f83551b8ca01ff949b03bc9a533d270204d6511a8ca9d *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)"

--- a/target/openjdk-16-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-16-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:16-slim-buster
 
-ENV CLOJURE_VERSION=1.10.1.619
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "28b1652686426cdf856f83551b8ca01ff949b03bc9a533d270204d6511a8ca9d *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-8-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-buster
 
-ENV CLOJURE_VERSION=1.10.1.561
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7f9e4e7c5a8171db4e4edf5ce78e5b8f453bae641a4c6b7f3dda36c3128d2ff7 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)"

--- a/target/openjdk-8-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim-buster
 
-ENV CLOJURE_VERSION=1.10.1.561
+ENV CLOJURE_VERSION=1.10.1.697
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7f9e4e7c5a8171db4e4edf5ce78e5b8f453bae641a4c6b7f3dda36c3128d2ff7 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "701fa850123821e0ce9c2eff6f673125445192abc3990bfaa0b03bd6f161403e *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-clojure -A:test
+clojure -M:test

--- a/update.sh
+++ b/update.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-clojure -m docker-clojure.core dockerfiles
+clojure -M -m docker-clojure.core dockerfiles


### PR DESCRIPTION
This is a pretty big release by tools-deps standards and deprecates quite a few CLI calling conventions. Since this project uses tools-deps itself, this PR also updates the `./update.sh`, `./test.sh`, and `./build-images.sh` scripts to use the new conventions.