### PR TITLE
Update: lein 2.9.5

### DIFF
--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -46,7 +46,7 @@
   {:default "slim-buster"})
 
 (def build-tools
-  {"lein"       "2.9.3"
+  {"lein"       "2.9.5"
    "boot"       "2.8.3"
    "tools-deps" "1.10.1.739"})
 

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -30,7 +30,7 @@
            "wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg"
            "echo \"Comparing lein-pkg checksum ...\""
            "sha256sum lein-pkg"
-           "echo \"42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg\" | sha256sum -c -"
+           "echo \"3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg\" | sha256sum -c -"
            "mv lein-pkg $LEIN_INSTALL/lein"
            "chmod 0755 $LEIN_INSTALL/lein"
            "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"

--- a/target/openjdk-11-buster/lein/Dockerfile
+++ b/target/openjdk-11-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-buster
 
-ENV LEIN_VERSION=2.9.3
+ENV LEIN_VERSION=2.9.5
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-11-slim-buster/latest/Dockerfile
+++ b/target/openjdk-11-slim-buster/latest/Dockerfile
@@ -28,7 +28,7 @@ ENV BOOT_AS_ROOT=yes
 RUN boot
 
 ### INSTALL LEIN ###
-ENV LEIN_VERSION=2.9.3
+ENV LEIN_VERSION=2.9.5
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -42,7 +42,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-11-slim-buster/lein/Dockerfile
+++ b/target/openjdk-11-slim-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim-buster
 
-ENV LEIN_VERSION=2.9.3
+ENV LEIN_VERSION=2.9.5
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-15-buster/lein/Dockerfile
+++ b/target/openjdk-15-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:15-buster
 
-ENV LEIN_VERSION=2.9.3
+ENV LEIN_VERSION=2.9.5
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-15-slim-buster/lein/Dockerfile
+++ b/target/openjdk-15-slim-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:15-slim-buster
 
-ENV LEIN_VERSION=2.9.3
+ENV LEIN_VERSION=2.9.5
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-16-alpine/lein/Dockerfile
+++ b/target/openjdk-16-alpine/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:16-alpine
 
-ENV LEIN_VERSION=2.9.3
+ENV LEIN_VERSION=2.9.5
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -12,7 +12,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-16-buster/lein/Dockerfile
+++ b/target/openjdk-16-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:16-buster
 
-ENV LEIN_VERSION=2.9.3
+ENV LEIN_VERSION=2.9.5
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-16-slim-buster/lein/Dockerfile
+++ b/target/openjdk-16-slim-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:16-slim-buster
 
-ENV LEIN_VERSION=2.9.3
+ENV LEIN_VERSION=2.9.5
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-8-buster/lein/Dockerfile
+++ b/target/openjdk-8-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-buster
 
-ENV LEIN_VERSION=2.9.3
+ENV LEIN_VERSION=2.9.5
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \

--- a/target/openjdk-8-slim-buster/lein/Dockerfile
+++ b/target/openjdk-8-slim-buster/lein/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim-buster
 
-ENV LEIN_VERSION=2.9.3
+ENV LEIN_VERSION=2.9.5
 ENV LEIN_INSTALL=/usr/local/bin/
 
 WORKDIR /tmp
@@ -14,7 +14,7 @@ mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \
 sha256sum lein-pkg && \
-echo "42e18e8a833b863ddfba1c5565bd5d78b54bcee661ec86e94a8bdc67b1733e63 *lein-pkg" | sha256sum -c - && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
 wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \


### PR DESCRIPTION
Leiningen fixed their packaging script that was making it hard to update to 2.9.4 (hence the version skip) and released 2.9.5. I'll merge this shortly. There is a tools-deps update coming hot on its heels too.