### PR TITLE
Add openjdk-17 variants

### DIFF
--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -33,7 +33,7 @@
 
 (def base-image "openjdk")
 
-(def jdk-versions #{8 11 15 16})
+(def jdk-versions #{8 11 15 16 17})
 
 ;; The default JDK version to use for tags that don't specify one; usually the latest LTS release
 (def default-jdk-version 11)
@@ -56,6 +56,8 @@
     {:jdk-version 11
      :distro      "alpine"}
     {:jdk-version 15
+     :distro      "alpine"}
+    {:jdk-version 16
      :distro      "alpine"}})
 
 (def maintainers

--- a/target/openjdk-17-alpine/boot/Dockerfile
+++ b/target/openjdk-17-alpine/boot/Dockerfile
@@ -1,0 +1,27 @@
+FROM openjdk:17-alpine
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apk add --update --no-cache bash openssl && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apk del openssl
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-17-alpine/lein/Dockerfile
+++ b/target/openjdk-17-alpine/lein/Dockerfile
@@ -1,0 +1,35 @@
+FROM openjdk:17-alpine
+
+ENV LEIN_VERSION=2.9.5
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apk add --update --no-cache ca-certificates bash tar openssl gnupg && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apk del ca-certificates tar openssl gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-17-alpine/tools-deps/Dockerfile
+++ b/target/openjdk-17-alpine/tools-deps/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:17-alpine
+
+ENV CLOJURE_VERSION=1.10.2.774
+
+WORKDIR /tmp
+
+RUN \
+apk add --update --no-cache curl bash make && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "6d39603e84ad2622e5ae601436f02a1ee4a57e4e35dc49098b01a7d142a13d4a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apk del curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-17-buster/boot/Dockerfile
+++ b/target/openjdk-17-buster/boot/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:17-buster
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-17-buster/lein/Dockerfile
+++ b/target/openjdk-17-buster/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:17-buster
+
+ENV LEIN_VERSION=2.9.5
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-17-buster/tools-deps/Dockerfile
+++ b/target/openjdk-17-buster/tools-deps/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:17-buster
+
+ENV CLOJURE_VERSION=1.10.2.774
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y make rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "6d39603e84ad2622e5ae601436f02a1ee4a57e4e35dc49098b01a7d142a13d4a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-17-slim-buster/boot/Dockerfile
+++ b/target/openjdk-17-slim-buster/boot/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:17-slim-buster
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-17-slim-buster/lein/Dockerfile
+++ b/target/openjdk-17-slim-buster/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:17-slim-buster
+
+ENV LEIN_VERSION=2.9.5
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-17-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-17-slim-buster/tools-deps/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:17-slim-buster
+
+ENV CLOJURE_VERSION=1.10.2.774
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "6d39603e84ad2622e5ae601436f02a1ee4a57e4e35dc49098b01a7d142a13d4a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]


### PR DESCRIPTION
...and stop building openjdk-16-alpine variants as upstream no longer supports it (as usual for non-EA alpine builds).