### PR TITLE
Update tools-deps to 1.10.3.855

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-clojure -M -m docker-clojure.core "$@"
+clojure -M -m docker-clojure.core

--- a/clean.sh
+++ b/clean.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-clojure -m docker-clojure.core clean
+clojure -M -m docker-clojure.core clean

--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -48,7 +48,7 @@
 (def build-tools
   {"lein"       "2.9.6"
    "boot"       "2.8.3"
-   "tools-deps" "1.10.3.839"})
+   "tools-deps" "1.10.3.855"})
 
 (def exclusions ; don't build these for whatever reason(s)
   #{{:jdk-version 8

--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -25,7 +25,7 @@
         (concat-commands
           ["wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"
            "sha256sum linux-install-$CLOJURE_VERSION.sh"
-           "echo \"ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh\" | sha256sum -c -"
+           "echo \"4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh\" | sha256sum -c -"
            "chmod +x linux-install-$CLOJURE_VERSION.sh"
            "./linux-install-$CLOJURE_VERSION.sh"
            "clojure -e \"(clojure-version)\""] (empty? uninstall-dep-cmds))

--- a/target/openjdk-11-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-buster
 
-ENV CLOJURE_VERSION=1.10.3.839
+ENV CLOJURE_VERSION=1.10.3.855
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)"

--- a/target/openjdk-11-slim-buster/latest/Dockerfile
+++ b/target/openjdk-11-slim-buster/latest/Dockerfile
@@ -63,7 +63,7 @@ RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' 
   && lein deps && rm project.clj
 
 ### INSTALL TOOLS-DEPS ###
-ENV CLOJURE_VERSION=1.10.3.839
+ENV CLOJURE_VERSION=1.10.3.855
 
 WORKDIR /tmp
 
@@ -73,7 +73,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-11-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim-buster
 
-ENV CLOJURE_VERSION=1.10.3.839
+ENV CLOJURE_VERSION=1.10.3.855
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-16-buster/tools-deps/Dockerfile
+++ b/target/openjdk-16-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:16-buster
 
-ENV CLOJURE_VERSION=1.10.3.839
+ENV CLOJURE_VERSION=1.10.3.855
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)"

--- a/target/openjdk-16-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-16-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:16-slim-buster
 
-ENV CLOJURE_VERSION=1.10.3.839
+ENV CLOJURE_VERSION=1.10.3.855
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-17-alpine/tools-deps/Dockerfile
+++ b/target/openjdk-17-alpine/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:17-alpine
 
-ENV CLOJURE_VERSION=1.10.3.839
+ENV CLOJURE_VERSION=1.10.3.855
 
 WORKDIR /tmp
 
@@ -8,7 +8,7 @@ RUN \
 apk add --update --no-cache curl bash make && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-17-buster/tools-deps/Dockerfile
+++ b/target/openjdk-17-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:17-buster
 
-ENV CLOJURE_VERSION=1.10.3.839
+ENV CLOJURE_VERSION=1.10.3.855
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)"

--- a/target/openjdk-17-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-17-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:17-slim-buster
 
-ENV CLOJURE_VERSION=1.10.3.839
+ENV CLOJURE_VERSION=1.10.3.855
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \

--- a/target/openjdk-8-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-buster
 
-ENV CLOJURE_VERSION=1.10.3.839
+ENV CLOJURE_VERSION=1.10.3.855
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)"

--- a/target/openjdk-8-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim-buster
 
-ENV CLOJURE_VERSION=1.10.3.839
+ENV CLOJURE_VERSION=1.10.3.855
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "ba754dcf1d88cd1e8fe8337637fe249b91dff4f63115b4b9550947539869c804 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "4bafe3c7343b7d4ef44bd0145bf4203be1c144a30d99a1db53ab67abb2568e2b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \


### PR DESCRIPTION
1.10.3.855 is the current stable version: https://github.com/clojure/brew-install/blob/1.10.3/CHANGELOG.md

It includes the changes from 1.10.3.849 which addresses some CVE security concerns: https://clojure.org/releases/tools#v1.10.3.855

I also reverted an earlier commit of mine after discovering that there are wrapper shell scripts for arguments to `docker-clojure.core/-main`, sorry about that.