### PR TITLE
Feature: build more alpine images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the repository for the [official Docker image for Clojure](https://registry.hub.docker.com/_/clojure/).
 It is automatically pulled and built by Stackbrew into the Docker registry.
-This image runs on OpenJDK 8, 11, 14, 15, and 16 and includes [Leiningen](http://leiningen.org),
+This image runs on OpenJDK 8, 11, and more recent releases and includes [Leiningen](http://leiningen.org),
 [boot](http://boot-clj.com), and/or [tools-deps](https://clojure.org/reference/deps_and_cli)
 (see below for tags and building instructions).
 
@@ -11,11 +11,11 @@ This image runs on OpenJDK 8, 11, 14, 15, and 16 and includes [Leiningen](http:/
 The version tags on these images look like `(openjdk-major-version-)lein-N.N.N(-distro)`,
 `(openjdk-major-version-)boot-N.N.N(-distro)`, and `(openjdk-major-version-)tools-deps(-distro)`.
 These refer to which version of leiningen, boot, or tools-deps is packaged in the image (because they can then install
-and use any version of Clojure at runtime). The `lein` (or `lein-slim-buster`, `openjdk-14-lein`, etc.)
+and use any version of Clojure at runtime). The `lein` (or `lein-slim-bullseye`, `openjdk-14-lein`, etc.)
 images will always have a recent version of leiningen installed. If you want boot, specify either `clojure:boot`,
-`clojure:boot-slim-buster`, or `clojure:boot-N.N.N`, `clojure:boot-N.N.N-slim-buster`,
-`clojure:openjdk-14-boot-N.N.N-slim-buster`, etc. (where `N.N.N` is the version of boot you want installed). If
-you want to use tools-deps, specify either `clojure:tools-deps`, `clojure:tools-deps-slim-buster` or other similar
+`clojure:boot-slim-bullseye`, or `clojure:boot-N.N.N`, `clojure:boot-N.N.N-slim-bullseye`,
+`clojure:openjdk-14-boot-N.N.N-slim-bullseye`, etc. (where `N.N.N` is the version of boot you want installed). If
+you want to use tools-deps, specify either `clojure:tools-deps`, `clojure:tools-deps-slim-bullseye` or other similar
 variants.
 
 ### Note about the latest tag
@@ -42,14 +42,13 @@ JDK 15 with boot 2.8.3: `clojure:openjdk-15-boot-2.8.3`
 ## Linux distro
 
 The upstream OpenJDK images are built on a few different variants of Debian Linux, so we have exposed those in our
-Docker tags as well. The default is now Debian slim-buster. But you can also specify which distro you'd like by
+Docker tags as well. The default is now Debian slim-bullseye. But you can also specify which distro you'd like by
 appending it to the end of your Docker tag as in the following examples (but note that not every combination is
 provided upstream and thus likewise for us):
 
-JDK 1.8 leiningen on Debian slim-buster: `clojure:openjdk-8` or `clojure:openjdk-8-lein` or `clojure:openjdk-8-lein-stretch`
+JDK 1.8 leiningen on Debian slim-bullseye: `clojure:openjdk-8` or `clojure:openjdk-8-lein` or `clojure:openjdk-8-lein-stretch`
 JDK 1.8 leiningen on Debian buster: `clojure:openjdk-8-buster` or `clojure:openjdk-8-lein-buster`
-JDK 11 tools-deps on Debian slim-buster: `clojure:tools-deps` or `clojure:openjdk-11-tools-deps` or `clojure:openjdk-11-tools-deps-slim-buster`
-JDK 15 tools-deps on Alpine: `clojure:openjdk-15-tools-deps-alpine`
+JDK 11 tools-deps on Debian slim-bullseye: `clojure:tools-deps` or `clojure:openjdk-11-tools-deps` or `clojure:openjdk-11-tools-deps-slim-bullseye`
 
 ## Alpine Linux
 
@@ -57,11 +56,11 @@ Most of the upstream alpine-based openjdk builds have been deprecated, so we hav
 only provides alpine variants of the current early access release. They tend to disappear once it becomes a full
 release.
 
-For other versions of OpenJDK, we recommend migrating to the `slim-buster` variant instead. The older `alpine` images
+For other versions of OpenJDK, we recommend migrating to the `slim-bullseye` variant instead. The older `alpine` images
 won't go away, but neither will they receive security updates, version bumps, etc. We recommend that you cease using
 them until / unless official upstream support resumes.
 
-### `clojure:slim-buster`
+### `clojure:slim-buster` / `clojure:slim-bullseye`
 
 These images are based on the Debian buster distribution but have fewer packages installed and are thus much smaller
 than the `stretch` or `buster` images. Their use is recommended.

--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -39,11 +39,11 @@
 (def default-jdk-version 11)
 
 (def distros
-  #{:debian/buster :debian-slim/slim-buster :alpine/alpine})
+  #{:debian/buster :debian-slim/slim-buster :debian/bullseye :debian-slim/slim-bullseye :alpine/alpine})
 
 ;; The default distro to use for tags that don't specify one, keyed by jdk-version.
 (def default-distros
-  {:default :debian-slim/slim-buster})
+  {:default :debian-slim/slim-bullseye})
 
 (def build-tools
   {"lein"       "2.9.6"

--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -54,12 +54,6 @@
   #{{:jdk-version 8
      :distro      :alpine/alpine}
     {:jdk-version 11
-     :distro      :alpine/alpine}
-    {:jdk-version 16
-     :distro      :alpine/alpine}
-    {:jdk-version 17
-     :distro      :alpine/alpine}
-    {:jdk-version 18
      :distro      :alpine/alpine}})
 
 (def maintainers

--- a/src/docker_clojure/dockerfile/boot.clj
+++ b/src/docker_clojure/dockerfile/boot.clj
@@ -3,10 +3,10 @@
             [clojure.string :as str]))
 
 (def distro-deps
-  {"slim-buster" {:build   #{"wget"}
-                  :runtime #{}}
-   "alpine"      {:build   #{"openssl"}
-                  :runtime #{"bash"}}})
+  {:debian-slim {:build   #{"wget"}
+                 :runtime #{}}
+   :alpine      {:build   #{"openssl"}
+                 :runtime #{"bash"}}})
 
 (def install-deps (partial install-distro-deps distro-deps))
 

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -3,12 +3,12 @@
             [docker-clojure.dockerfile.shared :refer :all]))
 
 (def distro-deps
-  {"slim-buster" {:build   #{"wget" "gnupg"}
-                  :runtime #{}}
-   "buster"      {:build   #{"gnupg"}
-                  :runtime #{}}
-   "alpine"      {:build   #{"tar" "gnupg" "openssl" "ca-certificates"}
-                  :runtime #{"bash"}}})
+  {:debian-slim {:build   #{"wget" "gnupg"}
+                 :runtime #{}}
+   :debian      {:build   #{"gnupg"}
+                 :runtime #{}}
+   :alpine      {:build   #{"tar" "gnupg" "openssl" "ca-certificates"}
+                 :runtime #{"bash"}}})
 
 (def install-deps (partial install-distro-deps distro-deps))
 

--- a/src/docker_clojure/dockerfile/shared.clj
+++ b/src/docker_clojure/dockerfile/shared.clj
@@ -11,7 +11,7 @@
            (when end? [(last cmds)]))))
 
 (defn get-deps [type distro-deps distro]
-  (->> distro namespace keyword (get distro-deps) type))
+  (some->> distro namespace keyword (get distro-deps) type))
 
 (def build-deps (partial get-deps :build))
 

--- a/src/docker_clojure/dockerfile/shared.clj
+++ b/src/docker_clojure/dockerfile/shared.clj
@@ -10,11 +10,12 @@
                 commands)
            (when end? [(last cmds)]))))
 
-(defn build-deps [distro-deps distro]
-  (-> distro-deps (get distro) :build))
+(defn get-deps [type distro-deps distro]
+  (->> distro namespace keyword (get distro-deps) type))
 
-(defn runtime-deps [distro-deps distro]
-  (-> distro-deps (get distro) :runtime))
+(def build-deps (partial get-deps :build))
+
+(def runtime-deps (partial get-deps :runtime))
 
 (defn all-deps [distro-deps distro]
   (set (concat (build-deps distro-deps distro)
@@ -23,13 +24,13 @@
 (defn install-distro-deps [distro-deps {:keys [distro]}]
   (let [deps (all-deps distro-deps distro)]
     (when (seq deps)
-      (case distro
-        ("slim-buster" "buster")
+      (case (-> distro namespace keyword)
+        (:debian :debian-slim)
         ["apt-get update"
          (str/join " " (concat ["apt-get install -y"] deps))
          "rm -rf /var/lib/apt/lists/*"]
 
-        "alpine"
+        :alpine
         [(str/join " " (concat ["apk add --update --no-cache"] deps))]
 
         nil))))
@@ -37,11 +38,11 @@
 (defn uninstall-distro-build-deps [distro-deps {:keys [distro]}]
   (let [deps (build-deps distro-deps distro)]
     (when (seq deps)
-      (case distro
-        ("slim-buster" "buster")
+      (case (-> distro namespace keyword)
+        (:debian :debian-slim)
         [(str/join " " (concat ["apt-get purge -y --auto-remove"] deps))]
 
-        "alpine"
+        :alpine
         [(str/join " " (concat ["apk del"] deps))]
 
         nil))))

--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -2,12 +2,12 @@
   (:require [docker-clojure.dockerfile.shared :refer :all]))
 
 (def distro-deps
-  {"slim-buster" {:build   #{"wget" "curl"}
-                  :runtime #{"rlwrap" "make"}}
-   "buster"      {:build   #{}
-                  :runtime #{"rlwrap" "make"}}
-   "alpine"      {:build   #{"curl"}
-                  :runtime #{"bash" "make"}}})
+  {:debian-slim {:build   #{"wget" "curl"}
+                 :runtime #{"rlwrap" "make"}}
+   :debian      {:build   #{}
+                 :runtime #{"rlwrap" "make"}}
+   :alpine      {:build   #{"curl"}
+                 :runtime #{"bash" "make"}}})
 
 (def install-deps (partial install-distro-deps distro-deps))
 

--- a/target/openjdk-11-bullseye/boot/Dockerfile
+++ b/target/openjdk-11-bullseye/boot/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:11-bullseye
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-11-bullseye/lein/Dockerfile
+++ b/target/openjdk-11-bullseye/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:11-bullseye
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-11-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-11-bullseye/tools-deps/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:11-bullseye
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y make rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-11-slim-bullseye/boot/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/boot/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:11-slim-bullseye
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-11-slim-bullseye/latest/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/latest/Dockerfile
@@ -1,0 +1,82 @@
+FROM openjdk:11-slim-bullseye
+
+### INSTALL BOOT ###
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+### INSTALL LEIN ###
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+### INSTALL TOOLS-DEPS ###
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+CMD ["lein", "repl"]

--- a/target/openjdk-11-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:11-slim-bullseye
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-11-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/tools-deps/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:11-slim-bullseye
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-16-alpine/boot/Dockerfile
+++ b/target/openjdk-16-alpine/boot/Dockerfile
@@ -1,0 +1,27 @@
+FROM openjdk:16-alpine
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apk add --update --no-cache bash openssl && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apk del openssl
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-16-alpine/lein/Dockerfile
+++ b/target/openjdk-16-alpine/lein/Dockerfile
@@ -1,0 +1,35 @@
+FROM openjdk:16-alpine
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apk add --update --no-cache ca-certificates bash tar openssl gnupg && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apk del ca-certificates tar openssl gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-16-alpine/tools-deps/Dockerfile
+++ b/target/openjdk-16-alpine/tools-deps/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:16-alpine
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apk add --update --no-cache curl bash make git && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apk del curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-16-bullseye/boot/Dockerfile
+++ b/target/openjdk-16-bullseye/boot/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:16-bullseye
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-16-bullseye/lein/Dockerfile
+++ b/target/openjdk-16-bullseye/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:16-bullseye
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-16-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-16-bullseye/tools-deps/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:16-bullseye
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y make rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-16-slim-bullseye/boot/Dockerfile
+++ b/target/openjdk-16-slim-bullseye/boot/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:16-slim-bullseye
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-16-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-16-slim-bullseye/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:16-slim-bullseye
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-16-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-16-slim-bullseye/tools-deps/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:16-slim-bullseye
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-17-alpine/boot/Dockerfile
+++ b/target/openjdk-17-alpine/boot/Dockerfile
@@ -1,0 +1,27 @@
+FROM openjdk:17-alpine
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apk add --update --no-cache bash openssl && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apk del openssl
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-17-alpine/lein/Dockerfile
+++ b/target/openjdk-17-alpine/lein/Dockerfile
@@ -1,0 +1,35 @@
+FROM openjdk:17-alpine
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apk add --update --no-cache ca-certificates bash tar openssl gnupg && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apk del ca-certificates tar openssl gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-17-alpine/tools-deps/Dockerfile
+++ b/target/openjdk-17-alpine/tools-deps/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:17-alpine
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apk add --update --no-cache curl bash make git && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apk del curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-17-bullseye/boot/Dockerfile
+++ b/target/openjdk-17-bullseye/boot/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:17-bullseye
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-17-bullseye/lein/Dockerfile
+++ b/target/openjdk-17-bullseye/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:17-bullseye
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-17-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-17-bullseye/tools-deps/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:17-bullseye
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y make rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-17-slim-bullseye/boot/Dockerfile
+++ b/target/openjdk-17-slim-bullseye/boot/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:17-slim-bullseye
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-17-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-17-slim-bullseye/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:17-slim-bullseye
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-17-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-17-slim-bullseye/tools-deps/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:17-slim-bullseye
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-18-alpine/boot/Dockerfile
+++ b/target/openjdk-18-alpine/boot/Dockerfile
@@ -1,0 +1,27 @@
+FROM openjdk:18-alpine
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apk add --update --no-cache bash openssl && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apk del openssl
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-18-alpine/lein/Dockerfile
+++ b/target/openjdk-18-alpine/lein/Dockerfile
@@ -1,0 +1,35 @@
+FROM openjdk:18-alpine
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apk add --update --no-cache ca-certificates bash tar openssl gnupg && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apk del ca-certificates tar openssl gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-18-alpine/tools-deps/Dockerfile
+++ b/target/openjdk-18-alpine/tools-deps/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:18-alpine
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apk add --update --no-cache curl bash make git && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apk del curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-18-bullseye/boot/Dockerfile
+++ b/target/openjdk-18-bullseye/boot/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:18-bullseye
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-18-bullseye/lein/Dockerfile
+++ b/target/openjdk-18-bullseye/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:18-bullseye
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-18-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-18-bullseye/tools-deps/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:18-bullseye
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y make rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-18-slim-bullseye/boot/Dockerfile
+++ b/target/openjdk-18-slim-bullseye/boot/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:18-slim-bullseye
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-18-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-18-slim-bullseye/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:18-slim-bullseye
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-18-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-18-slim-bullseye/tools-deps/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:18-slim-bullseye
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-8-bullseye/boot/Dockerfile
+++ b/target/openjdk-8-bullseye/boot/Dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:8-bullseye
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-8-bullseye/lein/Dockerfile
+++ b/target/openjdk-8-bullseye/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:8-bullseye
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-8-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-8-bullseye/tools-deps/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:8-bullseye
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y make rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)"
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/target/openjdk-8-slim-bullseye/boot/Dockerfile
+++ b/target/openjdk-8-slim-bullseye/boot/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:8-slim-bullseye
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/openjdk-8-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-8-slim-bullseye/lein/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:8-slim-bullseye
+
+ENV LEIN_VERSION=2.9.6
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
+rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.10.3 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/openjdk-8-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-8-slim-bullseye/tools-deps/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:8-slim-bullseye
+
+ENV CLOJURE_VERSION=1.10.3.943
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "f1fdb786fa8b9ef3a08d0b331a51861cd5a6eea277e93bbad64bf37774df17c6 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2019-10-2 this bug still exists, despite that issue being closed
+CMD ["sh", "-c", "sleep 1 && exec clj"]

--- a/test/docker_clojure/core_test.clj
+++ b/test/docker_clojure/core_test.clj
@@ -3,136 +3,129 @@
             [docker-clojure.core :refer :all]
             [clojure.string :as str]))
 
-(deftest default-distro-test
-  (testing "jdk-version 8 gets slim-buster"
-    (is (= "slim-buster" (default-distro 8))))
-  (testing "jdk-version 11 gets slim-buster"
-    (is (= "slim-buster" (default-distro 11))))
-  (testing "other versions get slim-buster"
-    (is (= "slim-buster" (default-distro 12)))
-    (is (= "slim-buster" (default-distro 14)))
-    (is (= "slim-buster" (default-distro 15)))))
-
 (deftest image-variants-test
   (testing "generates the expected set of variants"
-    (let [variants (image-variants #{8 11 14 15}
-                                   #{"buster" "slim-buster" "alpine"}
-                                   {"lein"       "2.9.1"
-                                    "boot"       "2.8.3"
-                                    "tools-deps" "1.10.1.478"})]
-      ;; filter is to make failure output a little more humane
-      (are [v] (contains? (->> variants
-                               (filter #(and (= (:jdk-version %) (:jdk-version v))
-                                             (= (:distro %)      (:distro v))
-                                             (= (:build-tool %)  (:build-tool v))))
-                               set)
-                          v)
-            {:jdk-version 11, :distro "slim-buster", :build-tool "lein"
-                 :base-image "openjdk:11-slim-buster"
-                 :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                 :docker-tag "lein-2.9.1", :build-tool-version "2.9.1"}
-            {:jdk-version 11, :distro "slim-buster", :build-tool "boot"
-                :base-image "openjdk:11-slim-buster"
-                :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                :docker-tag "boot-2.8.3", :build-tool-version "2.8.3"}
-            {:jdk-version 11, :distro "slim-buster"
-                :base-image "openjdk:11-slim-buster"
-                :build-tool "tools-deps"
-                :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                :docker-tag "tools-deps-1.10.1.478"
-                :build-tool-version "1.10.1.478"}
-            {:jdk-version 11, :distro "buster", :build-tool "lein"
-                :base-image "openjdk:11-buster"
-                :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                :docker-tag "lein-2.9.1-buster", :build-tool-version "2.9.1"}
-            {:jdk-version 11, :distro "buster", :build-tool "boot"
-                :base-image "openjdk:11-buster"
-                :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                :docker-tag "boot-2.8.3-buster", :build-tool-version "2.8.3"}
-            {:jdk-version 11, :distro "buster"
-             :base-image "openjdk:11-buster"
-             :build-tool "tools-deps"
-             :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "tools-deps-1.10.1.478-buster"
-             :build-tool-version "1.10.1.478"}
-            {:jdk-version 8, :distro "slim-buster", :build-tool "lein"
-             :base-image "openjdk:8-slim-buster"
-             :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-8-lein-2.9.1", :build-tool-version "2.9.1"}
-            {:jdk-version 8, :distro "slim-buster", :build-tool "boot"
-             :base-image "openjdk:8-slim-buster"
-             :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-8-boot-2.8.3", :build-tool-version "2.8.3"}
-            {:jdk-version 8, :distro "slim-buster"
-             :build-tool "tools-deps"
-             :base-image "openjdk:8-slim-buster"
-             :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-8-tools-deps-1.10.1.478"
-             :build-tool-version "1.10.1.478"}
-            {:jdk-version 14, :distro "slim-buster", :build-tool "lein"
-             :base-image "openjdk:14-slim-buster"
-             :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-14-lein-2.9.1"
-             :build-tool-version "2.9.1"}
-            {:jdk-version 15, :distro "alpine", :build-tool "lein"
-             :base-image "openjdk:15-alpine"
-             :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-15-lein-2.9.1-alpine"
-             :build-tool-version "2.9.1"}
-            {:jdk-version 15, :distro "alpine", :build-tool "boot"
-             :base-image "openjdk:15-alpine"
-             :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-15-boot-2.8.3-alpine"
-             :build-tool-version "2.8.3"}
-            {:jdk-version 15, :distro "alpine"
-             :base-image "openjdk:15-alpine"
-             :build-tool "tools-deps"
-             :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-             :docker-tag "openjdk-15-tools-deps-1.10.1.478-alpine"
-             :build-tool-version "1.10.1.478"}))))
+    (with-redefs [default-distro (constantly :debian/slim-buster)]
+      (let [variants (image-variants #{8 11 14 15}
+                                     #{:debian/buster :debian/slim-buster :alpine/alpine}
+                                     {"lein"       "2.9.1"
+                                      "boot"       "2.8.3"
+                                      "tools-deps" "1.10.1.478"})]
+        ;; filter is to make failure output a little more humane
+        (are [v] (contains? (->> variants
+                                 (filter #(and (= (:jdk-version %) (:jdk-version v))
+                                               (= (:distro %) (:distro v))
+                                               (= (:build-tool %) (:build-tool v))))
+                                 set)
+                            v)
+                 {:jdk-version 11, :distro :debian/slim-buster, :build-tool "lein"
+                  :base-image  "openjdk:11-slim-buster"
+                  :maintainer  "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag  "lein-2.9.1", :build-tool-version "2.9.1"}
+                 {:jdk-version 11, :distro :debian/slim-buster, :build-tool "boot"
+                  :base-image  "openjdk:11-slim-buster"
+                  :maintainer  "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag  "boot-2.8.3", :build-tool-version "2.8.3"}
+                 {:jdk-version        11, :distro :debian/slim-buster
+                  :base-image         "openjdk:11-slim-buster"
+                  :build-tool         "tools-deps"
+                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag         "tools-deps-1.10.1.478"
+                  :build-tool-version "1.10.1.478"}
+                 {:jdk-version 11, :distro :debian/buster, :build-tool "lein"
+                  :base-image  "openjdk:11-buster"
+                  :maintainer  "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag  "lein-2.9.1-buster", :build-tool-version "2.9.1"}
+                 {:jdk-version 11, :distro :debian/buster, :build-tool "boot"
+                  :base-image  "openjdk:11-buster"
+                  :maintainer  "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag  "boot-2.8.3-buster", :build-tool-version "2.8.3"}
+                 {:jdk-version        11, :distro :debian/buster
+                  :base-image         "openjdk:11-buster"
+                  :build-tool         "tools-deps"
+                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag         "tools-deps-1.10.1.478-buster"
+                  :build-tool-version "1.10.1.478"}
+                 {:jdk-version 8, :distro :debian/slim-buster, :build-tool "lein"
+                  :base-image  "openjdk:8-slim-buster"
+                  :maintainer  "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag  "openjdk-8-lein-2.9.1", :build-tool-version "2.9.1"}
+                 {:jdk-version 8, :distro :debian/slim-buster, :build-tool "boot"
+                  :base-image  "openjdk:8-slim-buster"
+                  :maintainer  "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag  "openjdk-8-boot-2.8.3", :build-tool-version "2.8.3"}
+                 {:jdk-version        8, :distro :debian/slim-buster
+                  :build-tool         "tools-deps"
+                  :base-image         "openjdk:8-slim-buster"
+                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag         "openjdk-8-tools-deps-1.10.1.478"
+                  :build-tool-version "1.10.1.478"}
+                 {:jdk-version        14, :distro :debian/slim-buster, :build-tool "lein"
+                  :base-image         "openjdk:14-slim-buster"
+                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag         "openjdk-14-lein-2.9.1"
+                  :build-tool-version "2.9.1"}
+                 {:jdk-version        15, :distro :alpine/alpine, :build-tool "lein"
+                  :base-image         "openjdk:15-alpine"
+                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag         "openjdk-15-lein-2.9.1-alpine"
+                  :build-tool-version "2.9.1"}
+                 {:jdk-version        15, :distro :alpine/alpine, :build-tool "boot"
+                  :base-image         "openjdk:15-alpine"
+                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag         "openjdk-15-boot-2.8.3-alpine"
+                  :build-tool-version "2.8.3"}
+                 {:jdk-version        15, :distro :alpine/alpine
+                  :base-image         "openjdk:15-alpine"
+                  :build-tool         "tools-deps"
+                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+                  :docker-tag         "openjdk-15-tools-deps-1.10.1.478-alpine"
+                  :build-tool-version "1.10.1.478"})))))
 
 (deftest variant-map-test
   (testing "returns the expected map version of the image variant list"
     (is (= {:jdk-version        8
             :base-image         "openjdk:8-distro"
-            :distro             "distro"
+            :distro             :distro/distro
             :build-tool         "build-tool"
             :docker-tag         "openjdk-8-build-tool-1.2.3-distro"
             :build-tool-version "1.2.3"
-            :maintainer "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"}
-           (variant-map '(8 "distro" ["build-tool" "1.2.3"]))))))
+            :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"}
+           (variant-map '(8 :distro/distro ["build-tool" "1.2.3"]))))))
 
 (deftest exclude?-test
   (testing "excludes variant that matches all key-values in any exclusion"
     (is (exclude? #{{:base-image "bad"}
                     {:base-image "not-great", :build-tool "woof"}}
-                  {:base-image "not-great" :build-tool "woof"
+                  {:base-image         "not-great" :build-tool "woof"
                    :build-tool-version "1.2.3"})))
   (testing "does not exclude partial matches"
     (is (not (exclude? #{{:base-image "bad", :build-tool "woof"}}
                        {:base-image "bad", :build-tool "boot"})))))
 
 (deftest docker-tag-test
-  (testing "default java version is left out"
-    (is (not (str/includes? (docker-tag {:jdk-version 11})
-                            "openjdk-11"))))
-  (testing "non-default version is added as a prefix"
-    (is (str/starts-with? (docker-tag {:jdk-version 14})
-                          "openjdk-14")))
-  (testing "default distro is left out"
-    (is (not (str/includes? (docker-tag {:jdk-version 14
-                                         :distro "slim-buster"})
-                            "slim-buster"))))
-  (testing "alpine is added as a suffix"
-    (is (str/ends-with? (docker-tag {:jdk-version 8
-                                     :distro "alpine"})
-                        "alpine")))
-  (testing "build tool is included"
-    (is (str/includes? (docker-tag {:jdk-version 11
-                                    :build-tool "lein"})
-                       "lein")))
-  (testing "build tool version is included"
-    (is (str/includes? (docker-tag {:jdk-version 11
-                                    :build-tool "boot"
-                                    :build-tool-version "2.8.1"})
-                       "2.8.1"))))
+  (with-redefs [default-jdk-version 11                      ; TODO: Make this an arg to the fn instead
+                default-distro (constantly :debian/slim-buster)] ; TODO: Rethink this too?
+    (testing "default java version is left out"
+      (is (not (str/includes? (docker-tag {:jdk-version 11})
+                              "openjdk-11"))))
+    (testing "non-default version is added as a prefix"
+      (is (str/starts-with? (docker-tag {:jdk-version 14})
+                            "openjdk-14")))
+    (testing "default distro is left out"
+      (is (not (str/includes? (docker-tag {:jdk-version 14
+                                           :distro      :debian/slim-buster})
+                              "slim-buster"))))
+    (testing "alpine is added as a suffix"
+      (is (str/ends-with? (docker-tag {:jdk-version 8
+                                       :distro      :alpine/alpine})
+                          "alpine")))
+    (testing "build tool is included"
+      (is (str/includes? (docker-tag {:jdk-version 11
+                                      :build-tool  "lein"})
+                         "lein")))
+    (testing "build tool version is included"
+      (is (str/includes? (docker-tag {:jdk-version        11
+                                      :build-tool         "boot"
+                                      :build-tool-version "2.8.1"})
+                         "2.8.1")))))


### PR DESCRIPTION
I noticed that the upstream openjdk folks added alpine images for versions 16, 17, and 18 at some point. So we can provide clojure images based on those now I think. Based on #117 so that should be approved and merged first.