### PR TITLE
Fix older lein builds

### DIFF
--- a/src/docker_clojure/dockerfile/boot.clj
+++ b/src/docker_clojure/dockerfile/boot.clj
@@ -12,7 +12,7 @@
 
 (def uninstall-build-deps (partial uninstall-distro-build-deps distro-deps))
 
-(defn install [{:keys [build-tool-version] :as variant}]
+(defn install [installer-hashes {:keys [build-tool-version] :as variant}]
   (let [install-dep-cmds   (install-deps variant)
         uninstall-dep-cmds (uninstall-build-deps variant)]
     (-> [(format "ENV BOOT_VERSION=%s" build-tool-version)
@@ -30,7 +30,7 @@
            "wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh"
            "echo \"Comparing installer checksum...\""
            "sha256sum boot.sh"
-           "echo \"0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh\" | sha256sum -c -"
+           (str "echo \"" (get-in installer-hashes ["boot" build-tool-version]) " *boot.sh\" | sha256sum -c -")
            "mv boot.sh $BOOT_INSTALL/boot"
            "chmod 0755 $BOOT_INSTALL/boot"] (empty? uninstall-dep-cmds))
         (concat-commands uninstall-dep-cmds :end)
@@ -46,5 +46,5 @@
 (def command
   ["CMD [\"boot\", \"repl\"]"])
 
-(defn contents [variant]
-  (concat (install variant) [""] command))
+(defn contents [installer-hashes variant]
+  (concat (install installer-hashes variant) [""] command))

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -39,7 +39,7 @@
             else \\
               gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \\
               FILENAME_EXT=zip; \\
-           fi"
+            fi"
            "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT"
            "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc"
            "echo \"Verifying file PGP signature...\""

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -14,7 +14,7 @@
 
 (def uninstall-build-deps (partial uninstall-distro-build-deps distro-deps))
 
-(defn install [{:keys [build-tool-version] :as variant}]
+(defn install [installer-hashes {:keys [build-tool-version] :as variant}]
   (let [install-dep-cmds   (install-deps variant)
         uninstall-dep-cmds (uninstall-build-deps variant)]
     (-> [(format "ENV LEIN_VERSION=%s" build-tool-version)
@@ -30,7 +30,7 @@
            "wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg"
            "echo \"Comparing lein-pkg checksum ...\""
            "sha256sum lein-pkg"
-           "echo \"094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg\" | sha256sum -c -"
+           (str "echo \"" (get-in installer-hashes ["lein" build-tool-version]) " *lein-pkg\" | sha256sum -c -")
            "mv lein-pkg $LEIN_INSTALL/lein"
            "chmod 0755 $LEIN_INSTALL/lein"
            "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"
@@ -57,5 +57,5 @@
 (def command
   ["CMD [\"lein\", \"repl\"]"])
 
-(defn contents [variant]
-  (concat (install variant) [""] command))
+(defn contents [installer-hashes variant]
+  (concat (install installer-hashes variant) [""] command))

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -1,6 +1,5 @@
 (ns docker-clojure.dockerfile.lein
-  (:require [clojure.string :as str]
-            [docker-clojure.dockerfile.shared :refer :all]))
+  (:require [docker-clojure.dockerfile.shared :refer :all]))
 
 (def distro-deps
   {:debian-slim {:build   #{"wget" "gnupg"}
@@ -23,7 +22,7 @@
          "WORKDIR /tmp"
          ""
          "# Download the whole repo as an archive"
-         "RUN \\"]
+         "RUN set -eux; \\"]
         (concat-commands install-dep-cmds)
         (concat-commands
           ["mkdir -p $LEIN_INSTALL"
@@ -33,14 +32,22 @@
            (str "echo \"" (get-in installer-hashes ["lein" build-tool-version]) " *lein-pkg\" | sha256sum -c -")
            "mv lein-pkg $LEIN_INSTALL/lein"
            "chmod 0755 $LEIN_INSTALL/lein"
-           "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"
-           "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc"
-           "gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3"
+           "export GNUPGHOME=\"$(mktemp -d)\""
+           "export FILENAME_EXT=jar"
+           "if printf '%s\\n%s\\n' \"2.9.7\" \"$LEIN_VERSION\" | sort -cV; then \\
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \\
+            else \\
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \\
+              FILENAME_EXT=zip; \\
+           fi"
+           "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT"
+           "wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc"
            "echo \"Verifying file PGP signature...\""
-           "gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip"
-           "rm leiningen-$LEIN_VERSION-standalone.zip.asc"
+           "gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT"
+           "gpgconf --kill all"
+           "rm -r \"$GNUPGHOME\" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc"
            "mkdir -p /usr/share/java"
-           "mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar"]
+           "mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar"]
           (empty? uninstall-dep-cmds))
         (concat-commands uninstall-dep-cmds :end)
         (concat

--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -13,7 +13,7 @@
 
 (def uninstall-build-deps (partial uninstall-distro-build-deps distro-deps))
 
-(defn install [{:keys [build-tool-version] :as variant}]
+(defn install [installer-hashes {:keys [build-tool-version] :as variant}]
   (let [install-dep-cmds   (install-deps variant)
         uninstall-dep-cmds (uninstall-build-deps variant)]
     (-> [(format "ENV CLOJURE_VERSION=%s" build-tool-version)
@@ -25,7 +25,7 @@
         (concat-commands
           ["wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"
            "sha256sum linux-install-$CLOJURE_VERSION.sh"
-           "echo \"d1fba0cd0733b7cb66e47620845ecedfd757a9bf84e8b276fdb37ed9c272d3ae *linux-install-$CLOJURE_VERSION.sh\" | sha256sum -c -"
+           (str "echo \"" (get-in installer-hashes ["tools-deps" build-tool-version]) " *linux-install-$CLOJURE_VERSION.sh\" | sha256sum -c -")
            "chmod +x linux-install-$CLOJURE_VERSION.sh"
            "./linux-install-$CLOJURE_VERSION.sh"
            "rm linux-install-$CLOJURE_VERSION.sh"
@@ -40,5 +40,5 @@
    "# As of 2019-10-2 this bug still exists, despite that issue being closed"
    "CMD [\"sh\", \"-c\", \"sleep 1 && exec clj\"]"])
 
-(defn contents [variant]
-  (concat (install variant) [""] command))
+(defn contents [installer-hashes variant]
+  (concat (install installer-hashes variant) [""] command))

--- a/target/openjdk-11-bullseye/lein/Dockerfile
+++ b/target/openjdk-11-bullseye/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-11-buster/lein/Dockerfile
+++ b/target/openjdk-11-buster/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-11-slim-bullseye/latest/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/latest/Dockerfile
@@ -34,7 +34,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -45,14 +45,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-11-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-11-slim-buster/lein/Dockerfile
+++ b/target/openjdk-11-slim-buster/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-16-bullseye/lein/Dockerfile
+++ b/target/openjdk-16-bullseye/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-16-buster/lein/Dockerfile
+++ b/target/openjdk-16-buster/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-16-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-16-slim-bullseye/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-16-slim-buster/lein/Dockerfile
+++ b/target/openjdk-16-slim-buster/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-17-bullseye/lein/Dockerfile
+++ b/target/openjdk-17-bullseye/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-17-buster/lein/Dockerfile
+++ b/target/openjdk-17-buster/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-17-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-17-slim-bullseye/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-17-slim-buster/lein/Dockerfile
+++ b/target/openjdk-17-slim-buster/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-18-alpine/lein/Dockerfile
+++ b/target/openjdk-18-alpine/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apk add --no-cache ca-certificates bash tar openssl gnupg && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg && \
@@ -15,14 +15,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apk del ca-certificates tar openssl gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-18-bullseye/lein/Dockerfile
+++ b/target/openjdk-18-bullseye/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-18-buster/lein/Dockerfile
+++ b/target/openjdk-18-buster/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-18-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-18-slim-bullseye/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-18-slim-buster/lein/Dockerfile
+++ b/target/openjdk-18-slim-buster/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-8-bullseye/lein/Dockerfile
+++ b/target/openjdk-8-bullseye/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-8-buster/lein/Dockerfile
+++ b/target/openjdk-8-buster/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-8-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-8-slim-bullseye/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/target/openjdk-8-slim-buster/lein/Dockerfile
+++ b/target/openjdk-8-slim-buster/lein/Dockerfile
@@ -6,7 +6,7 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # Download the whole repo as an archive
-RUN \
+RUN set -eux; \
 apt-get update && \
 apt-get install -y gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
@@ -17,14 +17,22 @@ sha256sum lein-pkg && \
 echo "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429 *lein-pkg" | sha256sum -c - && \
 mv lein-pkg $LEIN_INSTALL/lein && \
 chmod 0755 $LEIN_INSTALL/lein && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip && \
-wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc && \
-gpg --batch --keyserver keys.openpgp.org --recv-key 20242BACBBE95ADA22D0AFD7808A33D379C806C3 && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+           fi && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 echo "Verifying file PGP signature..." && \
-gpg --batch --verify leiningen-$LEIN_VERSION-standalone.zip.asc leiningen-$LEIN_VERSION-standalone.zip && \
-rm leiningen-$LEIN_VERSION-standalone.zip.asc && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -r "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
 mkdir -p /usr/share/java && \
-mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
 apt-get purge -y --auto-remove gnupg wget
 
 ENV PATH=$PATH:$LEIN_INSTALL

--- a/test/docker_clojure/dockerfile_test.clj
+++ b/test/docker_clojure/dockerfile_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [docker-clojure.dockerfile :refer :all]
+            [docker-clojure.core :as core]
             [docker-clojure.dockerfile.lein :as lein]
             [docker-clojure.dockerfile.boot :as boot]
             [docker-clojure.dockerfile.tools-deps :as tools-deps]))
@@ -14,30 +15,34 @@
 
 (deftest contents-test
   (testing "includes 'FROM base-image'"
-    (is (str/includes? (contents {:base-image "base:foo"
-                                  :build-tool "boot"})
+    (is (str/includes? (contents core/installer-hashes {:base-image "base:foo"
+                                                        :build-tool "boot"})
                        "FROM base:foo")))
   (testing "has no labels (Docker recommends against for base images)"
-    (is (not (str/includes? (contents {:base-image "base:foo"
+    (is (not (str/includes? (contents core/installer-hashes
+                                      {:base-image "base:foo"
                                        :build-tool "boot"
                                        :maintainer "Me Myself"})
                             "LABEL "))))
   (testing "lein variant includes lein-specific contents"
     (with-redefs [lein/contents (constantly ["leiningen vs. the ants"])]
-      (is (str/includes? (contents {:base-image "base:foo"
+      (is (str/includes? (contents core/installer-hashes
+                                   {:base-image "base:foo"
                                     :build-tool "lein"
                                     :maintainer "Me Myself"})
                          "leiningen vs. the ants"))))
   (testing "boot variant includes boot-specific contents"
     (with-redefs [boot/contents (constantly ["Booty McBootface"])]
-      (is (str/includes? (contents {:base-image "base:foo"
+      (is (str/includes? (contents core/installer-hashes
+                                   {:base-image "base:foo"
                                     :build-tool "boot"
                                     :maintainer "Me Myself"})
                          "Booty McBootface"))))
   (testing "tools-deps variant includes tools-deps-specific contents"
     (with-redefs [tools-deps/contents (constantly
                                        ["Tools Deps is not a build tool"])]
-      (is (str/includes? (contents {:base-image "base:foo"
+      (is (str/includes? (contents core/installer-hashes
+                                   {:base-image "base:foo"
                                     :build-tool "tools-deps"
                                     :maintainer "Me Myself"})
                          "Tools Deps is not a build tool")))))


### PR DESCRIPTION
While trying to address #132 I noticed that leiningen 2.9.6- versions weren't building because of the author's recent public key change. Fixing that led me to implement a couple things I've been meaning to improve anyway. 2.9.7 is out, but I want to get this and #126 in first before releasing that.