### PR TITLE
Update tools-deps to 1.10.3.1020 & build all working platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .cpcache/
 .nrepl-port
+target/**/images.tar
+

--- a/README.md
+++ b/README.md
@@ -95,9 +95,16 @@ build. Often this just means installing the `clojure` package for your system.
 
 The `./build-images.sh` script will generate the Dockerfiles and build all of the images.
 
+### buildx
+
 Note that you'll need to enable the new `buildx` feature and set as the default
 builder in the Docker daemon you're using to build the images. The build script
 uses some flags that require it.
+
+You'll also need to create a builder container with `docker buildx create --use`
+in order to build images for all supported platforms (currently linux/amd64 and
+linux/arm64).
+
 [Read the docs here](https://docs.docker.com/buildx/working-with-buildx/) for more info.
 
 ## Tests

--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -146,10 +146,21 @@
         {:keys [dockerfile build-dir]}
         (generate-dockerfile! installer-hashes variant)
 
-        ;; TODO: Build for all appropriate platforms instead of just linux/amd64.
-        ;;       alpine won't build for arm64.
-        build-cmd ["docker" "buildx" "build" "--no-cache" "--platform"
-                   "linux/amd64" "--load" "-t" image-tag "-f" dockerfile "."]]
+        ;; alpine won't build for arm64.
+        ;; boot crashes under qemu (i.e. non-host arch) but does anyone even
+        ;; use boot anymore?
+        platform-arg (cond
+                       (str/includes? image-tag "alpine")
+                       "--platform=linux/amd64"
+
+                       (str/includes? image-tag "boot")
+                       nil ; default to host arch
+
+                       :else
+                       "--platform=linux/amd64,linux/arm64")
+        build-cmd (remove nil? ["docker" "buildx" "build" "--no-cache"
+                                platform-arg "--output=type=tar,dest=images.tar"
+                                "-t" image-tag "-f" dockerfile "."])]
     (apply println "Running" build-cmd)
     (let [{:keys [out err exit]}
           (with-sh-dir build-dir (apply sh build-cmd))]

--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -48,16 +48,17 @@
 (def build-tools
   {"lein"       "2.9.7"
    "boot"       "2.8.3"
-   "tools-deps" "1.10.3.998"})
+   "tools-deps" "1.10.3.1020"})
 
 (def installer-hashes
   {"lein"       {"2.9.7" "f78f20d1931f028270e77bc0f0c00a5a0efa4ecb7a5676304a34ae4f469e281d"
                  "2.9.6" "094b58e2b13b42156aaf7d443ed5f6665aee27529d9512f8d7282baa3cc01429"}
    "boot"       {"2.8.3" "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3"}
-   "tools-deps" {"1.10.3.967" "d1fba0cd0733b7cb66e47620845ecedfd757a9bf84e8b276fdb37ed9c272d3ae"
-                 "1.10.3.981" "c6463a4f8950de6ce7982d01b72b660b9849c9a66d870081f5ee6b108220cf29"
-                 "1.10.3.986" "f2a271d6892fb04f7377148f6770185486ca194245721ab34a62ae03e8d1149f"
-                 "1.10.3.998" "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8"}})
+   "tools-deps" {"1.10.3.967"  "d1fba0cd0733b7cb66e47620845ecedfd757a9bf84e8b276fdb37ed9c272d3ae"
+                 "1.10.3.981"  "c6463a4f8950de6ce7982d01b72b660b9849c9a66d870081f5ee6b108220cf29"
+                 "1.10.3.986"  "f2a271d6892fb04f7377148f6770185486ca194245721ab34a62ae03e8d1149f"
+                 "1.10.3.998"  "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8"
+                 "1.10.3.1020" "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a"}})
 
 (def exclusions ; don't build these for whatever reason(s)
   #{{:jdk-version 8

--- a/target/openjdk-11-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-11-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-bullseye
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-buster
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-slim-bullseye/latest/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/latest/Dockerfile
@@ -71,7 +71,7 @@ RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' 
   && lein deps && rm project.clj
 
 ### INSTALL TOOLS-DEPS ###
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -81,7 +81,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim-bullseye
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim-buster
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-17-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-17-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:17-bullseye
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-17-buster/tools-deps/Dockerfile
+++ b/target/openjdk-17-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:17-buster
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-17-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-17-slim-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:17-slim-bullseye
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-17-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-17-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:17-slim-buster
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-18-alpine/tools-deps/Dockerfile
+++ b/target/openjdk-18-alpine/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:18-alpine
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -8,7 +8,7 @@ RUN \
 apk add --no-cache curl bash make git && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-18-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-18-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:18-bullseye
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-18-buster/tools-deps/Dockerfile
+++ b/target/openjdk-18-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:18-buster
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-18-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-18-slim-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:18-slim-bullseye
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-18-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-18-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:18-slim-buster
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-8-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-bullseye
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-buster
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-8-slim-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim-bullseye
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim-buster
 
-ENV CLOJURE_VERSION=1.10.3.998
+ENV CLOJURE_VERSION=1.10.3.1020
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "c58df29f0c919b90282ace43e92fffd914ba50ba619c837d232bbf686f6ee4a8 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "afc87e2c8cfbf87e43553439c69a4c8e36bc2094405d08f39ca542b4cca0920a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \


### PR DESCRIPTION
Mostly a standard version bump but also took the opportunity to have the builder code build all working platforms (which is _really_ slow)