### PR TITLE
Update tools-deps variants & add a feature for filtering variants in CLI commands

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,13 +1,15 @@
 {:paths ["src"]
- :deps {local/deps {:local/root "."}
-        org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
-                                 :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}
+ :deps  {local/deps              {:local/root "."}
+         org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
+                                  :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}
  :tasks
- {:requires ([docker-clojure.core :as dc])
-  clean (dc/-main "clean")
-  dockerfiles (dc/-main "dockerfiles")
-  manifest (dc/-main "manifest")
-  build-images (dc/-main "build-images")
-  test {:extra-paths ["test"]
-        :requires ([docker-clojure.test-runner :as tr])
-        :task (tr/-main 'docker-clojure.core-test 'docker-clojure.dockerfile-test)}}}
+ {:requires    ([docker-clojure.core :as dc])
+  clean        (dc/-main "clean")
+  dockerfiles  {:depends [clean]
+                :task    (apply dc/-main "dockerfiles" *command-line-args*)}
+  manifest     (apply dc/-main "manifest" *command-line-args*)
+  build-images {:depends [clean]
+                :task    (apply dc/-main "build-images" *command-line-args*)}
+  test         {:extra-paths ["test"]
+                :requires    ([docker-clojure.test-runner :as tr])
+                :task        (tr/-main 'docker-clojure.core-test 'docker-clojure.dockerfile-test)}}}

--- a/src/docker_clojure/config.clj
+++ b/src/docker_clojure/config.clj
@@ -75,7 +75,7 @@
 (def build-tools
   {"lein"       "2.9.8"
    "boot"       "2.8.3"
-   "tools-deps" "1.11.1.1113"})
+   "tools-deps" "1.11.1.1124"})
 
 (def default-build-tool "tools-deps")
 
@@ -86,7 +86,8 @@
    "boot"       {"2.8.3" "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3"}
    "tools-deps" {"1.11.0.1100" "a71bd520bd43d4be6e0cab0c525f5d1f85911fc276f3d0f37f00243fb0f1e594"
                  "1.11.1.1105" "5655c3ee3ea495d0778d8a87ce05a719045d3ceae9dd5cc29033379d8f82cce5"
-                 "1.11.1.1113" "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f"}})
+                 "1.11.1.1113" "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f"
+                 "1.11.1.1124" "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db"}})
 
 (def exclusions ; don't build these for whatever reason(s)
   #{{:jdk-version 8

--- a/src/docker_clojure/config.clj
+++ b/src/docker_clojure/config.clj
@@ -75,7 +75,7 @@
 (def build-tools
   {"lein"       "2.9.8"
    "boot"       "2.8.3"
-   "tools-deps" "1.11.1.1124"})
+   "tools-deps" "1.11.1.1129"})
 
 (def default-build-tool "tools-deps")
 
@@ -87,7 +87,8 @@
    "tools-deps" {"1.11.0.1100" "a71bd520bd43d4be6e0cab0c525f5d1f85911fc276f3d0f37f00243fb0f1e594"
                  "1.11.1.1105" "5655c3ee3ea495d0778d8a87ce05a719045d3ceae9dd5cc29033379d8f82cce5"
                  "1.11.1.1113" "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f"
-                 "1.11.1.1124" "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db"}})
+                 "1.11.1.1124" "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db"
+                 "1.11.1.1129" "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123"}})
 
 (def exclusions ; don't build these for whatever reason(s)
   #{{:jdk-version 8

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -59,8 +59,8 @@
            "ENV PATH=$PATH:$LEIN_INSTALL"
            "ENV LEIN_ROOT 1"
            ""
-           "# Install clojure 1.10.3 so users don't have to download it every time"
-           "RUN echo '(defproject dummy \"\" :dependencies [[org.clojure/clojure \"1.10.3\"]])' > project.clj \\"
+           "# Install clojure 1.11.1 so users don't have to download it every time"
+           "RUN echo '(defproject dummy \"\" :dependencies [[org.clojure/clojure \"1.11.1\"]])' > project.clj \\"
            "  && lein deps && rm project.clj"])
 
         (->> (remove nil?)))))

--- a/target/eclipse-temurin-17-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-alpine/lein/Dockerfile
@@ -36,8 +36,8 @@ apk del ca-certificates tar openssl gnupg
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 COPY entrypoint /usr/local/bin/entrypoint

--- a/target/eclipse-temurin-17-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-alpine/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jdk-alpine
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -8,7 +8,7 @@ RUN \
 apk add --no-cache curl bash make git && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-17-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-alpine/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jdk-alpine
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -8,7 +8,7 @@ RUN \
 apk add --no-cache curl bash make git && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-17-jdk-focal/latest/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/latest/Dockerfile
@@ -71,7 +71,7 @@ RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' 
   && lein deps && rm project.clj
 
 ### INSTALL TOOLS-DEPS ###
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -81,7 +81,7 @@ apt-get install -y make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-17-jdk-focal/latest/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/latest/Dockerfile
@@ -66,12 +66,12 @@ apt-get purge -y --auto-remove gnupg wget
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 ### INSTALL TOOLS-DEPS ###
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -81,7 +81,7 @@ apt-get install -y make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-17-jdk-focal/lein/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/lein/Dockerfile
@@ -38,8 +38,8 @@ apt-get purge -y --auto-remove gnupg wget
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 COPY entrypoint /usr/local/bin/entrypoint

--- a/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jdk-focal
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jdk-focal
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-18-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-18-jdk-alpine/lein/Dockerfile
@@ -36,8 +36,8 @@ apk del ca-certificates tar openssl gnupg
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 COPY entrypoint /usr/local/bin/entrypoint

--- a/target/eclipse-temurin-18-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-18-jdk-alpine/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:18-jdk-alpine
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -8,7 +8,7 @@ RUN \
 apk add --no-cache curl bash make git && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-18-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-18-jdk-alpine/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:18-jdk-alpine
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -8,7 +8,7 @@ RUN \
 apk add --no-cache curl bash make git && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-18-jdk-focal/lein/Dockerfile
+++ b/target/eclipse-temurin-18-jdk-focal/lein/Dockerfile
@@ -38,8 +38,8 @@ apt-get purge -y --auto-remove gnupg wget
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 COPY entrypoint /usr/local/bin/entrypoint

--- a/target/eclipse-temurin-18-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-18-jdk-focal/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:18-jdk-focal
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-18-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-18-jdk-focal/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:18-jdk-focal
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-bullseye/lein/Dockerfile
+++ b/target/openjdk-11-bullseye/lein/Dockerfile
@@ -38,8 +38,8 @@ apt-get purge -y --auto-remove gnupg
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 CMD ["lein", "repl"]

--- a/target/openjdk-11-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-11-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-bullseye
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-11-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-bullseye
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-buster/lein/Dockerfile
+++ b/target/openjdk-11-buster/lein/Dockerfile
@@ -38,8 +38,8 @@ apt-get purge -y --auto-remove gnupg
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 CMD ["lein", "repl"]

--- a/target/openjdk-11-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-buster
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-buster
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/lein/Dockerfile
@@ -38,8 +38,8 @@ apt-get purge -y --auto-remove gnupg wget
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 CMD ["lein", "repl"]

--- a/target/openjdk-11-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim-bullseye
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-11-slim-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim-bullseye
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-slim-buster/lein/Dockerfile
+++ b/target/openjdk-11-slim-buster/lein/Dockerfile
@@ -38,8 +38,8 @@ apt-get purge -y --auto-remove gnupg wget
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 CMD ["lein", "repl"]

--- a/target/openjdk-11-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim-buster
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-11-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-11-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim-buster
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-bullseye/lein/Dockerfile
+++ b/target/openjdk-8-bullseye/lein/Dockerfile
@@ -38,8 +38,8 @@ apt-get purge -y --auto-remove gnupg
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 CMD ["lein", "repl"]

--- a/target/openjdk-8-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-8-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-bullseye
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-8-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-bullseye
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-buster/lein/Dockerfile
+++ b/target/openjdk-8-buster/lein/Dockerfile
@@ -38,8 +38,8 @@ apt-get purge -y --auto-remove gnupg
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 CMD ["lein", "repl"]

--- a/target/openjdk-8-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-buster
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-buster
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y make rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-slim-bullseye/lein/Dockerfile
+++ b/target/openjdk-8-slim-bullseye/lein/Dockerfile
@@ -38,8 +38,8 @@ apt-get purge -y --auto-remove gnupg wget
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 CMD ["lein", "repl"]

--- a/target/openjdk-8-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-8-slim-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim-bullseye
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-slim-bullseye/tools-deps/Dockerfile
+++ b/target/openjdk-8-slim-bullseye/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim-bullseye
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-slim-buster/lein/Dockerfile
+++ b/target/openjdk-8-slim-buster/lein/Dockerfile
@@ -38,8 +38,8 @@ apt-get purge -y --auto-remove gnupg wget
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 
-# Install clojure 1.10.3 so users don't have to download it every time
-RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.10.3"]])' > project.clj \
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
   && lein deps && rm project.clj
 
 CMD ["lein", "repl"]

--- a/target/openjdk-8-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim-buster
 
-ENV CLOJURE_VERSION=1.11.1.1113
+ENV CLOJURE_VERSION=1.11.1.1124
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \

--- a/target/openjdk-8-slim-buster/tools-deps/Dockerfile
+++ b/target/openjdk-8-slim-buster/tools-deps/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-slim-buster
 
-ENV CLOJURE_VERSION=1.11.1.1124
+ENV CLOJURE_VERSION=1.11.1.1129
 
 WORKDIR /tmp
 
@@ -10,7 +10,7 @@ apt-get install -y curl make git rlwrap wget && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
-echo "9c7d226ae1c08b6dbb7f10c9ca1ab8c80f8d5021b6a1e535b5dd92ba3ff062db *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+echo "02bec16a9bc0a7a1a7912ca72fc8042f46e106369e572ca7185a8522e8f40123 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \


### PR DESCRIPTION
I added the variant filtering so when I'm doing PRs like this I can run e.g. this:

`bb run build-images :build-tool tools-deps` and only build those images rather than waiting on / visually filtering out the lein and boot variants.