### PR TITLE
Fix latest cmd

### DIFF
--- a/src/docker_clojure/dockerfile.clj
+++ b/src/docker_clojure/dockerfile.clj
@@ -36,7 +36,7 @@
             (get-in variant [:build-tool-versions "tools-deps"])))
     [""]
     (entrypoint variant)
-    ["" "CMD [\"repl\"]"]))
+    ["" "CMD [\"-M\", \"--repl\"]"]))
 
 (defn contents [installer-hashes {:keys [build-tool] :as variant}]
   (str/join "\n"

--- a/target/eclipse-temurin-17-jdk-focal/latest/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/latest/Dockerfile
@@ -97,4 +97,4 @@ COPY entrypoint /usr/local/bin/entrypoint
 
 ENTRYPOINT ["entrypoint"]
 
-CMD ["repl"]
+CMD ["-M", "--repl"]


### PR DESCRIPTION
Fixes #164 

The latest image defaults to clj entrypoint (tools.deps) so it needs that tool's REPL invoker as the default CMD. You can still do e.g. `docker run -ti clojure lein repl`.