### PR TITLE
Fix build-tool-only tags

### DIFF
--- a/src/docker_clojure/manifest.clj
+++ b/src/docker_clojure/manifest.clj
@@ -14,7 +14,9 @@
           (docker-tag {:omit-jdk? true} variant)
           (docker-tag {:omit-build-tool? true} variant)
           (docker-tag {:omit-build-tool-version? true} variant)
-          (docker-tag {:omit-distro? true} variant))
+          (docker-tag {:omit-distro? true} variant)
+          (docker-tag {:omit-jdk? true, :omit-distro? true
+                       :omit-build-tool-version? true} variant))
         vec
         sort)))
 

--- a/src/docker_clojure/util.clj
+++ b/src/docker_clojure/util.clj
@@ -41,8 +41,8 @@
                                             (= build-tool cfg/default-build-tool))
                                      nil
                                      build-tool)
-          build-tool-version-label (if (and (or omit-all? omit-build-tool?
-                                                omit-build-tool-version?))
+          build-tool-version-label (if (or omit-all? omit-build-tool?
+                                           omit-build-tool-version?)
                                      nil
                                      build-tool-version)]
       (str/join "-" (remove nil? [jdk build-tool-label


### PR DESCRIPTION
The new manifest generation code was inadvertently not generating the `tools-deps`, `lein`, and `boot` tags which we used to have in the manually-maintained manifest and are handy for one-off commands and what not. This restores those to the programmatically-generated manifest.