### PR TITLE
Fix missing tags

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -12,4 +12,5 @@
                 :task    (apply dc/-main "build-images" *command-line-args*)}
   test         {:extra-paths ["test"]
                 :requires    ([docker-clojure.test-runner :as tr])
-                :task        (tr/-main 'docker-clojure.core-test 'docker-clojure.dockerfile-test)}}}
+                :task        (tr/-main 'docker-clojure.core-test 'docker-clojure.dockerfile-test
+                               'docker-clojure.manifest-test)}}}

--- a/src/docker_clojure/manifest.clj
+++ b/src/docker_clojure/manifest.clj
@@ -15,6 +15,8 @@
           (docker-tag {:omit-build-tool? true} variant)
           (docker-tag {:omit-build-tool-version? true} variant)
           (docker-tag {:omit-distro? true} variant)
+          (docker-tag {:omit-distro? true, :omit-build-tool-version? true} variant)
+          (docker-tag {:omit-jdk? true, :omit-build-tool-version? true} variant)
           (docker-tag {:omit-jdk? true, :omit-distro? true
                        :omit-build-tool-version? true} variant))
         vec

--- a/test/docker_clojure/manifest_test.clj
+++ b/test/docker_clojure/manifest_test.clj
@@ -1,0 +1,33 @@
+(ns docker-clojure.manifest-test
+  (:require [clojure.test :refer :all]
+            [docker-clojure.manifest :refer :all]))
+
+(deftest variant-tags-test
+  (testing "Generates all-defaults tag for a build tool"
+    (let [tags (variant-tags {:base-image         "eclipse-temurin"
+                              :jdk-version        17
+                              :distro             :ubuntu/jammy
+                              :build-tool         "tools-deps"
+                              :build-tool-version "1.11.1.1155"})]
+      (is ((set tags) "tools-deps"))))
+  (testing "Generates jdk-version-build-tool tag for every jdk version"
+    (are [jdk-version tag]
+      (let [tags (variant-tags {:base-image         "eclipse-temurin"
+                                :jdk-version        jdk-version
+                                :distro             :ubuntu/jammy
+                                :build-tool         "tools-deps"
+                                :build-tool-version "1.11.1.1155"})]
+        ((set tags) tag))
+      11 "temurin-11-tools-deps"
+      17 "temurin-17-tools-deps"
+      18 "temurin-18-tools-deps"))
+  (testing "Generates build-tool-distro tag for every distro"
+    (are [distro tag]
+      (let [tags (variant-tags {:base-image         "eclipse-temurin"
+                                :jdk-version        17
+                                :distro             distro
+                                :build-tool         "tools-deps"
+                                :build-tool-version "1.11.1.1155"})]
+        ((set tags) tag))
+      :ubuntu/focal "tools-deps-focal"
+      :ubuntu/jammy "tools-deps-jammy")))


### PR DESCRIPTION
Noticed there were still some missing tag variants in the manifest, so I wrote some tests for the missing ones and then got them to pass. Need to add more tests for the working ones for regression-catching. But that's for later.