### PR TITLE
Debian base images: The Return

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: turtlequeue/setup-babashka@v1.3.0
       with:
-        babashka-version: 0.8.1
+        babashka-version: 0.10.163
     - uses: actions/checkout@v2
     - name: Run tests
       run: bb run test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: turtlequeue/setup-babashka@v1.3.0
+    - name: Install babashka
+      uses: DeLaGuardo/setup-clojure@9.5
       with:
-        babashka-version: 0.10.163
+        bb: 0.10.163
     - uses: actions/checkout@v2
     - name: Run tests
       run: bb run test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the repository for the [official Docker image for Clojure](https://registry.hub.docker.com/_/clojure/).
 It is automatically pulled and built by Stackbrew into the Docker registry.
-This image runs on OpenJDK 8, 11, and more recent releases and includes [Leiningen](http://leiningen.org),
+This image runs on OpenJDK 8, 11, 17, and more recent releases and includes [Leiningen](http://leiningen.org),
 [boot](http://boot-clj.com), and/or [tools-deps](https://clojure.org/reference/deps_and_cli)
 (see below for tags and building instructions).
 
@@ -11,11 +11,11 @@ This image runs on OpenJDK 8, 11, and more recent releases and includes [Leining
 The version tags on these images look like `(temurin-major-version-)lein-N.N.N(-distro)`,
 `(temurin-major-version-)boot-N.N.N(-distro)`, and `(temurin-major-version-)tools-deps(-distro)`.
 These refer to which version of leiningen, boot, or tools-deps is packaged in the image (because they can then install
-and use any version of Clojure at runtime). The `lein` (or `lein-slim-bullseye`, `temurin-17-lein`, etc.)
+and use any version of Clojure at runtime). The `lein` (or `lein-bullseye-slim`, `temurin-17-lein`, etc.)
 images will always have a recent version of leiningen installed. If you want boot, specify either `clojure:boot`,
-`clojure:boot-slim-bullseye`, or `clojure:boot-N.N.N`, `clojure:boot-N.N.N-slim-bullseye`,
-`clojure:temurin-17-boot-N.N.N-slim-bullseye`, etc. (where `N.N.N` is the version of boot you want installed). If
-you want to use tools-deps, specify either `clojure:tools-deps`, `clojure:tools-deps-slim-bullseye` or other similar
+`clojure:boot-bullseye-slim`, or `clojure:boot-N.N.N`, `clojure:boot-N.N.N-bullseye-slim`,
+`clojure:temurin-17-boot-N.N.N-bullseye-slim`, etc. (where `N.N.N` is the version of boot you want installed). If
+you want to use tools-deps, specify either `clojure:tools-deps`, `clojure:tools-deps-bullseye-slim` or other similar
 variants.
 
 ### Note about the latest tag
@@ -34,36 +34,48 @@ Java follows a release cadence of every 6 months with an LTS (long-term support)
 As of 2019-9-25, our images will default to the latest LTS release of OpenJDK (currently 17). But we also now provide
 the ability to specify which version of Java you'd like via Docker tags:
 
-JDK 1.8 tools-deps image: `clojure:openjdk-8-tools-deps`
-JDK 11 variant of that image: `clojure:openjdk-11-tools-deps` or `clojure:tool-deps`
-JDK 17 with the latest release of leiningen: `clojure:temurin-17`
-JDK 18 with boot 2.8.3: `clojure:temurin-18-boot-2.8.3`
+JDK 1.8 tools-deps image: `clojure:temurin-8-tools-deps`
+JDK 11 variant of the tools-deps image: `clojure:temurin-11-tools-deps` or `clojure:temurin-11`
+JDK 17 variant of the tools-deps image: `clojure:tools-deps` or `clojure:temurin-17` or `clojure:temurin-17-tools-deps`
+JDK 19 with boot 2.8.3: `clojure:temurin-19-boot-2.8.3`
 
 ## Linux distro
 
-The upstream openjdk (java versions 11 and below) and eclipse-temurin
-(java versions 17+) images are built on a few different variants of Debian
-Linux or Ubuntu (respectively), so we have exposed those in our Docker tags as
-well. The defaults are now Debian slim-bullseye and Ubuntu focal.
-But you can also specify which distro you'd like by appending it to the end of
+The upstream eclipse-temurin images are built on different versions of Ubuntu,
+so we have exposed those in our Docker tags as well. However, Ubuntu is not the
+best distro for Docker images in many cases. In particular, their insistence on
+replacing traditional dpkg packages with snaps renders them essentially
+unusable inside containers because they need a daemon running to even install.
+To mitigate this we provide Debian-based images that copy the Java bits from
+the eclipse-temurin images (which is what the Temurin folks recommend when you
+want a different base image than what they provide). It is recommended to use
+the Debian variants unless you have a need to use Ubuntu or stick closer to the
+official upstream images.
+
+As of 2022-9-29 the default distro is Ubuntu jammy in order to maintain
+backwards compatibility. But you should not interpret this default as a
+recommendation. Use Debian bullseye or bullseye-slim variants unless you have
+a good, specific reason not to. There are fewer dead ends that way.
+
+You can specify which distro & version you'd like by appending it to the end of
 your Docker tag as in the following examples (but note that not every
 combination is provided upstream and thus likewise for us):
 
-Java 8 leiningen on Debian slim-bullseye: `clojure:openjdk-8` or `clojure:openjdk-8-lein` or `clojure:openjdk-8-lein-bullseye`
-Java 11 leiningen on Debian buster: `clojure:openjdk-11-bullseye` or `clojure:openjdk-11-lein-bullseye`
-Java 17 tools-deps on Ubuntu focal: `clojure:tools-deps` or `clojure:temurin-17-tools-deps` or `clojure:temurin-17-tools-deps-focal`
+Java 8 leiningen on Debian bullseye-slim: `clojure:temurin-8-lein-bullseye-slim`
+Java 11 leiningen on Debian bullseye: `clojure:temurin-11-lein-bullseye`
+Java 17 tools-deps on Ubuntu focal: `clojure:tools-deps` or `clojure:temurin-17` or `clojure:temurin-17-tools-deps` or `clojure:temurin-17-tools-deps-focal`
+Java 17 tools-deps on Debian bullseye-slim: `clojure:bullseye-slim` or `clojure:tools-deps-bullseye-slim` or `clojure:temurin-17-bullseye-slim` or `clojure:temurin-17-tools-deps-bullseye-slim`
 
 ### Alpine Linux
 
-Sometimes there are upstream openjdk or eclipse-temurin images based on Alpine
-Linux.
+Sometimes there are upstream eclipse-temurin images based on Alpine Linux.
 
-As of 2022-4-29 these are available for linux/amd64 only.
+As of 2022-9-29 these are available for the linux/amd64 architecture only.
 
 Some example tags:
 
 Java 17 leiningen on Alpine: `clojure:temurin-17-alpine` `clojure:temurin-17-lein-alpine`
-Java 18 tools-deps on Alpine: `clojure:temurin-18-tools-deps-alpine`
+Java 19 tools-deps on Alpine: `clojure:temurin-19-tools-deps-alpine` or `clojure:temurin-19-alpine`
 
 ### `clojure:slim-buster` / `clojure:slim-bullseye`
 
@@ -71,7 +83,7 @@ These images are based on the Debian buster distribution but have fewer
 packages installed and are thus a bit smaller than the `buster` or `bullseye`
 images. Their use is recommended.
 
-Note that as of 2022-4-29 there are no `slim-focal` images published by the
+Note that as of 2022-9-29 there are no `slim-focal` images published by the
 eclipse-temurin maintainers, so the slim option there is the `alpine` variant.
 
 ## Examples
@@ -81,7 +93,7 @@ eclipse-temurin maintainers, so the slim option there is the `alpine` variant.
 Run an interactive shell from this image.
 
 ```
-docker run -i -t clojure /bin/bash
+docker run -ti clojure bash
 ```
 
 Then within the shell, create a new Leiningen project and start a Clojure REPL.
@@ -96,10 +108,13 @@ lein repl
 
 The Dockerfiles are generated by the `docker-clojure` Clojure app in this repo.
 
-You'll need the `tools-deps` distribution of Clojure installed to run the
-build. Often this just means installing the `clojure` package for your system. 
+You'll need a recent version of [Babashka](https://babashka.org/) installed to
+run the builds.
 
-The `./build-images.sh` script will generate the Dockerfiles and build all of the images.
+Take a look at the `:tasks` key in the `bb.edn` file in the root of this repo.
+Each of these can be invoked via `bb run [task]` at the command line.
+
+For example, to build all images locally, run `bb run build-images`.
 
 ### buildx
 
@@ -116,4 +131,4 @@ linux/arm64).
 ## Tests
 
 The `docker-clojure` build tool has a test suite that can be run via the
-`./test.sh` script. 
+`bb run test` script. 

--- a/bb.edn
+++ b/bb.edn
@@ -8,8 +8,7 @@
   dockerfiles  {:depends [clean]
                 :task    (apply dc/-main "dockerfiles" *command-line-args*)}
   manifest     (apply dc/-main "manifest" *command-line-args*)
-  build-images {:depends [clean]
-                :task    (apply dc/-main "build-images" *command-line-args*)}
+  build-images {:task    (apply dc/-main "build-images" *command-line-args*)}
   test         {:extra-paths ["test"]
                 :requires    ([docker-clojure.test-runner :as tr])
                 :task        (tr/-main 'docker-clojure.core-test 'docker-clojure.dockerfile-test

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,16 @@
 {:deps
  {org.clojure/clojure            {:mvn/version "1.11.1"}
-  org.clojure/math.combinatorics {:mvn/version "0.1.6"}}
+  org.clojure/math.combinatorics {:mvn/version "0.1.6"}
+  org.clojure/core.async         {:mvn/version "1.5.648"}}
 
  :paths ["src" "resources"]
 
  :aliases
- {:test {:extra-paths ["test"]
+ {:build-images {:exec-fn docker-clojure.core/run
+                 :exec-args {:cmd :build-images
+                             :parallelization 2}}
+
+  :test {:extra-paths ["test"]
          :extra-deps  {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                   :sha     "4e7e1c0dfd5291fa2134df052443dc29695d8cbe"}}
          :main-opts   ["-m" "cognitect.test-runner"]}}}

--- a/src/docker_clojure/config.clj
+++ b/src/docker_clojure/config.clj
@@ -42,8 +42,8 @@
 (def jdk-versions #{8 11 17 18})
 
 (def base-images
-  "Map of JDK version to base image name with :default as a fallback"
-  {:default "eclipse-temurin"})
+  "Map of JDK version to base image name(s) with :default as a fallback"
+  {:default ["eclipse-temurin" "debian"]})
 
 ;; The default JDK version to use for tags that don't specify one; usually the latest LTS release
 (def default-jdk-version 17)
@@ -51,7 +51,8 @@
 (def distros
   "Map of base image name to set of distro tags to use, namespaced by Linux
   distro type. :default key is a fallback for base images not o/w specified."
-  {:default #{:alpine/alpine :ubuntu/focal :ubuntu/jammy}})
+  {:default #{:alpine/alpine :ubuntu/focal :ubuntu/jammy}
+   "debian" #{:debian-slim/bullseye-slim :debian/bullseye}})
 
 (def default-architectures
   #{"amd64" "arm64v8"})

--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -4,11 +4,13 @@
     [clojure.math.combinatorics :as combo]
     [clojure.spec.alpha :as s]
     [clojure.string :as str]
+    [clojure.core.async :refer [<!! chan to-chan! pipeline-blocking] :as async]
     [docker-clojure.config :as cfg]
     [docker-clojure.dockerfile :as df]
     [docker-clojure.manifest :as manifest]
     [docker-clojure.util :refer [get-or-default default-docker-tag
                                  full-docker-tag]]
+    [docker-clojure.log :refer [log] :as logger]
     [clojure.edn :as edn]))
 
 (defn contains-every-key-value?
@@ -69,7 +71,7 @@
 (defn generate-dockerfile! [installer-hashes variant]
   (let [build-dir (df/build-dir variant)
         filename  "Dockerfile"]
-    (println "Generating" (str build-dir "/" filename))
+    (log "Generating" (str build-dir "/" filename))
     (df/write-file build-dir filename installer-hashes variant)
     (assoc variant
       :build-dir build-dir
@@ -78,7 +80,7 @@
 (defn build-image
   [installer-hashes {:keys [docker-tag base-image architectures] :as variant}]
   (let [image-tag     (str "clojure:" docker-tag)
-        _             (println "Pulling base image" base-image)
+        _             (log "Pulling base image" base-image)
         _             (pull-image base-image)
 
         {:keys [dockerfile build-dir]}
@@ -97,15 +99,14 @@
         build-cmd     (remove nil? ["docker" "buildx" "build" "--no-cache"
                                     "-t" image-tag platform-flag "--load"
                                     "-f" dockerfile "."])]
-    (apply println "Running" build-cmd)
+    (apply log "Running" build-cmd)
     (let [{:keys [out err exit]}
           (with-sh-dir build-dir (apply sh build-cmd))]
       (if (zero? exit)
-        (println "Succeeded")
-        (do
-          (println "ERROR:" err)
-          (print out)))))
-  (println))
+        (log "Succeeded building" (str "clojure:" docker-tag))
+        (log "ERROR building" (str "clojure:" docker-tag ":") err out))))
+  (log)
+  [::done variant])
 
 (def latest-variant
   "The latest variant is special because we include all 3 build tools via the
@@ -137,10 +138,14 @@
                                       build-tools)
           latest-variant)))
 
-(defn build-images [installer-hashes variants]
-  (println "Building images")
-  (doseq [variant variants]
-    (build-image installer-hashes variant)))
+(defn build-images [parallelization installer-hashes variants]
+  (log "Building images" parallelization "at a time")
+  (let [variants-ch (to-chan! variants)
+        builds-ch   (chan parallelization)]
+    (async/thread (pipeline-blocking parallelization builds-ch
+                                     (map (partial build-image installer-hashes))
+                                     variants-ch))
+    (while (<!! builds-ch))))
 
 (defn generate-dockerfiles! [installer-hashes variants]
   (doseq [variant variants]
@@ -157,7 +162,7 @@
                                      :architectures cfg/default-architectures
                                      :git-repo      cfg/git-repo}
                                     git-head variants)]
-    (println "Writing manifest of" (count variants) "variants to clojure.manifest...")
+    (log "Writing manifest of" (count variants) "variants to clojure.manifest...")
     (spit "clojure.manifest" manifest)))
 
 (defn sort-variants
@@ -180,8 +185,8 @@
 
 (defn generate-variants
   [& args]
-  (let [variant-filter-key (some-> args second edn/read-string)
-        variant-filter-val (nth args 2 nil)
+  (let [variant-filter-key (some-> args first edn/read-string)
+        variant-filter-val (nth args 1 nil)
         variant-filter     (if variant-filter-key
                              (if variant-filter-val
                                #(= (get % variant-filter-key)
@@ -190,9 +195,22 @@
                              (constantly true))]
     (filter variant-filter (valid-variants))))
 
+(defn run
+  "Entrypoint for exec-fn. TODO: Make -main use this."
+  [args]
+  (logger/start)
+  (let [variants (generate-variants (:variant-filter-key args) (:variant-filter-val args))]
+    (log "Generated" (count variants) "variants")
+    (case (:cmd args)
+      :clean (df/clean-all)
+      :dockerfiles (generate-dockerfiles! cfg/installer-hashes variants)
+      :manifest (->> variants sort-variants generate-manifest!)
+      :build-images (build-images (:parallelization args) cfg/installer-hashes variants)))
+  (logger/stop))
+
 (defn -main
   [& args]
-  (let [variants (apply generate-variants args)]
+  (let [variants (apply generate-variants (rest args))]
     (case (first args)
       "clean" (df/clean-all)
       "dockerfiles" (generate-dockerfiles! cfg/installer-hashes variants)

--- a/src/docker_clojure/dockerfile/boot.clj
+++ b/src/docker_clojure/dockerfile/boot.clj
@@ -6,7 +6,8 @@
 (def distro-deps
   {:debian-slim {:build   #{"wget"}
                  :runtime #{}}
-   :debian      {:runtime #{"make"}}
+   :debian      {:build   #{"wget"}
+                 :runtime #{"make"}}
    :ubuntu      {:build   #{"wget"}
                  :runtime #{}}
    :alpine      {:build   #{"openssl"}

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -6,7 +6,7 @@
 (def distro-deps
   {:debian-slim {:build   #{"wget" "gnupg"}
                  :runtime #{}}
-   :debian      {:build   #{"gnupg"}
+   :debian      {:build   #{"wget" "gnupg"}
                  :runtime #{"make"}}
    :ubuntu      {:build   #{"wget" "gnupg"}
                  :runtime #{"make"}}

--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -8,7 +8,7 @@
 (def distro-deps
   {:debian-slim {:build   #{"wget" "curl"}
                  :runtime #{"rlwrap" "make" "git"}}
-   :debian      {:build   #{}
+   :debian      {:build   #{"wget" "curl"}
                  :runtime #{"rlwrap" "make"}}
    :ubuntu      {:build   #{"wget"}
                  :runtime #{"rlwrap" "make" "git"}}

--- a/src/docker_clojure/log.clj
+++ b/src/docker_clojure/log.clj
@@ -1,0 +1,22 @@
+(ns docker-clojure.log
+  (:require [clojure.core.async :refer [chan put! <!! close!] :as async]))
+
+;; init w/ closed chan so that start works the same on first startup as subsequent ones
+(defonce log-ch (doto (chan) close!))
+
+(defn start []
+  (when (nil? (<!! log-ch))
+    (alter-var-root #'log-ch (constantly (chan 10)))
+    (async/thread
+      (loop []
+        (when-let [msgs (<!! log-ch)]
+          (apply println msgs)
+          (recur))))))
+
+(defn stop []
+  (close! log-ch))
+
+(defn log
+  [& msgs]
+  (let [msgs (if (nil? msgs) "" msgs)]
+    (put! log-ch msgs)))

--- a/src/docker_clojure/util.clj
+++ b/src/docker_clojure/util.clj
@@ -11,12 +11,12 @@
 (defn jdk-label
   [omit-default? jdk-version base-image]
   (if (and omit-default? (= cfg/default-jdk-version jdk-version)
-           (= (get-or-default cfg/base-images jdk-version)
+           (= (first (get-or-default cfg/base-images jdk-version))
               base-image))
     nil
     (str
       (case base-image
-        "eclipse-temurin" "temurin"
+        ("eclipse-temurin" "debian") "temurin"
         base-image)
       "-" jdk-version)))
 

--- a/target/debian-bullseye-11/boot/Dockerfile
+++ b/target/debian-bullseye-11/boot/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y make wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/debian-bullseye-11/boot/entrypoint
+++ b/target/debian-bullseye-11/boot/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=boot
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-11/lein/Dockerfile
+++ b/target/debian-bullseye-11/lein/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.9.10
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y make gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "dbb84d13d6df5b85bbf7f89a39daeed103133c24a4686d037fe6bd65e38e7f32 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+            fi && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/debian-bullseye-11/lein/entrypoint
+++ b/target/debian-bullseye-11/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-11/tools-deps/Dockerfile
+++ b/target/debian-bullseye-11/tools-deps/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.11.1.1165
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "72d662bdc99b79037f9e34996272384de35e01e0416d8eb79cc940ee0f0fc808 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+CMD ["clj"]

--- a/target/debian-bullseye-11/tools-deps/entrypoint
+++ b/target/debian-bullseye-11/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-11/tools-deps/rlwrap.retry
+++ b/target/debian-bullseye-11/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-bullseye-17/boot/Dockerfile
+++ b/target/debian-bullseye-17/boot/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y make wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-bullseye-17/boot/entrypoint
+++ b/target/debian-bullseye-17/boot/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=boot
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-17/lein/Dockerfile
+++ b/target/debian-bullseye-17/lein/Dockerfile
@@ -1,0 +1,52 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.9.10
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y make gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "dbb84d13d6df5b85bbf7f89a39daeed103133c24a4686d037fe6bd65e38e7f32 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+            fi && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-bullseye-17/lein/entrypoint
+++ b/target/debian-bullseye-17/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-17/tools-deps/Dockerfile
+++ b/target/debian-bullseye-17/tools-deps/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.11.1.1165
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "72d662bdc99b79037f9e34996272384de35e01e0416d8eb79cc940ee0f0fc808 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["-M", "--repl"]

--- a/target/debian-bullseye-17/tools-deps/entrypoint
+++ b/target/debian-bullseye-17/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-17/tools-deps/rlwrap.retry
+++ b/target/debian-bullseye-17/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-bullseye-18/boot/Dockerfile
+++ b/target/debian-bullseye-18/boot/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:18 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y make wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-bullseye-18/boot/entrypoint
+++ b/target/debian-bullseye-18/boot/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=boot
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-18/lein/Dockerfile
+++ b/target/debian-bullseye-18/lein/Dockerfile
@@ -1,0 +1,52 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:18 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.9.10
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y make gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "dbb84d13d6df5b85bbf7f89a39daeed103133c24a4686d037fe6bd65e38e7f32 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+            fi && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-bullseye-18/lein/entrypoint
+++ b/target/debian-bullseye-18/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-18/tools-deps/Dockerfile
+++ b/target/debian-bullseye-18/tools-deps/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:18 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.11.1.1165
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "72d662bdc99b79037f9e34996272384de35e01e0416d8eb79cc940ee0f0fc808 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["-M", "--repl"]

--- a/target/debian-bullseye-18/tools-deps/entrypoint
+++ b/target/debian-bullseye-18/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-18/tools-deps/rlwrap.retry
+++ b/target/debian-bullseye-18/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-bullseye-8/boot/Dockerfile
+++ b/target/debian-bullseye-8/boot/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y make wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/debian-bullseye-8/boot/entrypoint
+++ b/target/debian-bullseye-8/boot/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=boot
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-8/lein/Dockerfile
+++ b/target/debian-bullseye-8/lein/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.9.10
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y make gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "dbb84d13d6df5b85bbf7f89a39daeed103133c24a4686d037fe6bd65e38e7f32 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+            fi && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/debian-bullseye-8/lein/entrypoint
+++ b/target/debian-bullseye-8/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-8/tools-deps/Dockerfile
+++ b/target/debian-bullseye-8/tools-deps/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:bullseye
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.11.1.1165
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "72d662bdc99b79037f9e34996272384de35e01e0416d8eb79cc940ee0f0fc808 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+CMD ["clj"]

--- a/target/debian-bullseye-8/tools-deps/entrypoint
+++ b/target/debian-bullseye-8/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-8/tools-deps/rlwrap.retry
+++ b/target/debian-bullseye-8/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-bullseye-slim-11/boot/Dockerfile
+++ b/target/debian-bullseye-slim-11/boot/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/debian-bullseye-slim-11/boot/entrypoint
+++ b/target/debian-bullseye-slim-11/boot/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=boot
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-11/lein/Dockerfile
+++ b/target/debian-bullseye-slim-11/lein/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.9.10
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "dbb84d13d6df5b85bbf7f89a39daeed103133c24a4686d037fe6bd65e38e7f32 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+            fi && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/debian-bullseye-slim-11/lein/entrypoint
+++ b/target/debian-bullseye-slim-11/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-11/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-11/tools-deps/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.11.1.1165
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "72d662bdc99b79037f9e34996272384de35e01e0416d8eb79cc940ee0f0fc808 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+CMD ["clj"]

--- a/target/debian-bullseye-slim-11/tools-deps/entrypoint
+++ b/target/debian-bullseye-slim-11/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-11/tools-deps/rlwrap.retry
+++ b/target/debian-bullseye-slim-11/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-bullseye-slim-17/boot/Dockerfile
+++ b/target/debian-bullseye-slim-17/boot/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-bullseye-slim-17/boot/entrypoint
+++ b/target/debian-bullseye-slim-17/boot/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=boot
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-17/lein/Dockerfile
+++ b/target/debian-bullseye-slim-17/lein/Dockerfile
@@ -1,0 +1,52 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.9.10
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "dbb84d13d6df5b85bbf7f89a39daeed103133c24a4686d037fe6bd65e38e7f32 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+            fi && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-bullseye-slim-17/lein/entrypoint
+++ b/target/debian-bullseye-slim-17/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-17/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-17/tools-deps/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.11.1.1165
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "72d662bdc99b79037f9e34996272384de35e01e0416d8eb79cc940ee0f0fc808 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["-M", "--repl"]

--- a/target/debian-bullseye-slim-17/tools-deps/entrypoint
+++ b/target/debian-bullseye-slim-17/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-17/tools-deps/rlwrap.retry
+++ b/target/debian-bullseye-slim-17/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-bullseye-slim-18/boot/Dockerfile
+++ b/target/debian-bullseye-slim-18/boot/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:18 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-bullseye-slim-18/boot/entrypoint
+++ b/target/debian-bullseye-slim-18/boot/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=boot
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-18/lein/Dockerfile
+++ b/target/debian-bullseye-slim-18/lein/Dockerfile
@@ -1,0 +1,52 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:18 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.9.10
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "dbb84d13d6df5b85bbf7f89a39daeed103133c24a4686d037fe6bd65e38e7f32 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+            fi && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-bullseye-slim-18/lein/entrypoint
+++ b/target/debian-bullseye-slim-18/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-18/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-18/tools-deps/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:18 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.11.1.1165
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "72d662bdc99b79037f9e34996272384de35e01e0416d8eb79cc940ee0f0fc808 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["-M", "--repl"]

--- a/target/debian-bullseye-slim-18/tools-deps/entrypoint
+++ b/target/debian-bullseye-slim-18/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-18/tools-deps/rlwrap.retry
+++ b/target/debian-bullseye-slim-18/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-bullseye-slim-8/boot/Dockerfile
+++ b/target/debian-bullseye-slim-8/boot/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV BOOT_VERSION=2.8.3
+ENV BOOT_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# NOTE: BOOT_VERSION tells the boot.sh script which version of boot to install
+# on its first run. We always download the latest version of boot.sh because
+# it is just the installer script.
+RUN \
+apt-get update && \
+apt-get install -y wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $BOOT_INSTALL && \
+wget -q https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && \
+echo "Comparing installer checksum..." && \
+sha256sum boot.sh && \
+echo "0ccd697f2027e7e1cd3be3d62721057cbc841585740d0aaa9fbb485d7b1f17c3 *boot.sh" | sha256sum -c - && \
+mv boot.sh $BOOT_INSTALL/boot && \
+chmod 0755 $BOOT_INSTALL/boot && \
+apt-get purge -y --auto-remove wget
+
+ENV PATH=$PATH:$BOOT_INSTALL
+ENV BOOT_AS_ROOT=yes
+
+RUN boot
+
+CMD ["boot", "repl"]

--- a/target/debian-bullseye-slim-8/boot/entrypoint
+++ b/target/debian-bullseye-slim-8/boot/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=boot
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-8/lein/Dockerfile
+++ b/target/debian-bullseye-slim-8/lein/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.9.10
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "dbb84d13d6df5b85bbf7f89a39daeed103133c24a4686d037fe6bd65e38e7f32 *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+if printf '%s\n%s\n' "2.9.7" "$LEIN_VERSION" | sort -cV; then \
+              gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 6A2D483DB59437EBB97D09B1040193357D0606ED; \
+            else \
+              gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 20242BACBBE95ADA22D0AFD7808A33D379C806C3; \
+              FILENAME_EXT=zip; \
+            fi && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.11.1 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.11.1"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/debian-bullseye-slim-8/lein/entrypoint
+++ b/target/debian-bullseye-slim-8/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-8/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-8/tools-deps/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:bullseye-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.11.1.1165
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap wget && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "72d662bdc99b79037f9e34996272384de35e01e0416d8eb79cc940ee0f0fc808 *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl wget
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+CMD ["clj"]

--- a/target/debian-bullseye-slim-8/tools-deps/entrypoint
+++ b/target/debian-bullseye-slim-8/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-bullseye-slim-8/tools-deps/rlwrap.retry
+++ b/target/debian-bullseye-slim-8/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/test/docker_clojure/core_test.clj
+++ b/test/docker_clojure/core_test.clj
@@ -7,22 +7,18 @@
 
 (deftest image-variants-test
   (testing "generates the expected set of variants"
-    (with-redefs [cfg/default-distros     {8        :debian-slim/slim-buster
-                                           11       :debian-slim/slim-buster
+    (with-redefs [cfg/default-distros     {8        :debian-slim/buster-slim
+                                           11       :debian-slim/buster-slim
                                            :default :ubuntu/focal}
-                  cfg/base-images         {8        "openjdk"
-                                           11       "openjdk"
-                                           :default "eclipse-temurin"}
                   cfg/default-jdk-version 11
                   cfg/maintainers         ["Paul Lam <paul@quantisan.com>"
                                            "Wes Morgan <wesmorgan@icloud.com>"]]
-      (let [variants (image-variants {8        "openjdk"
-                                      11       "openjdk"
-                                      :default "eclipse-temurin"}
-                                     #{8 11 17}
-                                     {"openjdk" #{:debian/buster
-                                                  :debian-slim/slim-buster
-                                                  :alpine/alpine}
+      (let [variants (image-variants {8        ["debian"]
+                                      11       ["debian"]
+                                      :default ["eclipse-temurin"]}
+                                     #{8 11 17 18}
+                                     {"debian" #{:debian/buster
+                                                 :debian-slim/buster-slim}
                                       :default  #{:alpine/alpine :ubuntu/focal}}
                                      {"lein"       "2.9.1"
                                       "boot"       "2.8.3"
@@ -35,52 +31,52 @@
                                                (= (:build-tool %) (:build-tool v))))
                                  set)
                             v)
-                 {:jdk-version 11, :distro :debian-slim/slim-buster, :build-tool "lein"
-                  :base-image  "openjdk" :base-image-tag "openjdk:11-slim-buster"
+                 {:jdk-version 11, :distro :debian-slim/buster-slim, :build-tool "lein"
+                  :base-image  "debian" :base-image-tag "debian:buster-slim"
                   :maintainer  "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag  "lein-2.9.1", :build-tool-version "2.9.1"}
-                 {:jdk-version 11, :distro :debian-slim/slim-buster, :build-tool "boot"
-                  :base-image  "openjdk" :base-image-tag "openjdk:11-slim-buster"
+                  :docker-tag  "temurin-11-lein-2.9.1", :build-tool-version "2.9.1"}
+                 {:jdk-version 18, :distro :ubuntu/focal, :build-tool "boot"
+                  :base-image  "eclipse-temurin" :base-image-tag "eclipse-temurin:18-jdk-focal"
                   :maintainer  "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag  "boot-2.8.3", :build-tool-version "2.8.3"}
-                 {:jdk-version        11, :distro :debian-slim/slim-buster
-                  :base-image         "openjdk"
-                  :base-image-tag     "openjdk:11-slim-buster"
+                  :docker-tag  "temurin-18-boot-2.8.3", :build-tool-version "2.8.3"}
+                 {:jdk-version        18, :distro :ubuntu/focal
+                  :base-image         "eclipse-temurin"
+                  :base-image-tag     "eclipse-temurin:18-jdk-focal"
                   :build-tool         "tools-deps"
                   :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "tools-deps-1.10.1.478"
+                  :docker-tag         "temurin-18-tools-deps-1.10.1.478"
                   :build-tool-version "1.10.1.478"}
                  {:jdk-version 11, :distro :debian/buster, :build-tool "lein"
-                  :base-image  "openjdk" :base-image-tag "openjdk:11-buster"
+                  :base-image  "debian" :base-image-tag "debian:buster"
                   :maintainer  "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag  "lein-2.9.1-buster", :build-tool-version "2.9.1"}
+                  :docker-tag  "temurin-11-lein-2.9.1-buster", :build-tool-version "2.9.1"}
                  {:jdk-version 11, :distro :debian/buster, :build-tool "boot"
-                  :base-image  "openjdk" :base-image-tag "openjdk:11-buster"
+                  :base-image  "debian" :base-image-tag "debian:buster"
                   :maintainer  "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag  "boot-2.8.3-buster", :build-tool-version "2.8.3"}
+                  :docker-tag  "temurin-11-boot-2.8.3-buster", :build-tool-version "2.8.3"}
                  {:jdk-version        11, :distro :debian/buster
-                  :base-image         "openjdk"
-                  :base-image-tag     "openjdk:11-buster"
+                  :base-image         "debian"
+                  :base-image-tag     "debian:buster"
                   :build-tool         "tools-deps"
                   :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "tools-deps-1.10.1.478-buster"
+                  :docker-tag         "temurin-11-tools-deps-1.10.1.478-buster"
                   :build-tool-version "1.10.1.478"}
-                 {:jdk-version    8, :distro :debian-slim/slim-buster, :build-tool "lein"
-                  :base-image     "openjdk"
-                  :base-image-tag "openjdk:8-slim-buster"
+                 {:jdk-version    8, :distro :debian-slim/buster-slim, :build-tool "lein"
+                  :base-image     "debian"
+                  :base-image-tag "debian:buster-slim"
                   :maintainer     "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag     "openjdk-8-lein-2.9.1", :build-tool-version "2.9.1"}
-                 {:jdk-version    8, :distro :debian-slim/slim-buster, :build-tool "boot"
-                  :base-image     "openjdk"
-                  :base-image-tag "openjdk:8-slim-buster"
+                  :docker-tag     "temurin-8-lein-2.9.1", :build-tool-version "2.9.1"}
+                 {:jdk-version    8, :distro :debian-slim/buster-slim, :build-tool "boot"
+                  :base-image     "debian"
+                  :base-image-tag "debian:buster-slim"
                   :maintainer     "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag     "openjdk-8-boot-2.8.3", :build-tool-version "2.8.3"}
-                 {:jdk-version        8, :distro :debian-slim/slim-buster
+                  :docker-tag     "temurin-8-boot-2.8.3", :build-tool-version "2.8.3"}
+                 {:jdk-version        8, :distro :debian-slim/buster-slim
                   :build-tool         "tools-deps"
-                  :base-image         "openjdk"
-                  :base-image-tag     "openjdk:8-slim-buster"
+                  :base-image         "debian"
+                  :base-image-tag     "debian:buster-slim"
                   :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "openjdk-8-tools-deps-1.10.1.478"
+                  :docker-tag         "temurin-8-tools-deps-1.10.1.478"
                   :build-tool-version "1.10.1.478"}
                  {:jdk-version        17, :distro :ubuntu/focal, :build-tool "lein"
                   :base-image         "eclipse-temurin"
@@ -113,14 +109,14 @@
     (with-redefs [cfg/maintainers ["Paul Lam <paul@quantisan.com>"
                                    "Wes Morgan <wesmorgan@icloud.com>"]]
       (is (= {:jdk-version        8
-              :base-image         "openjdk"
-              :base-image-tag     "openjdk:8-distro"
+              :base-image         "eclipse-temurin"
+              :base-image-tag     "eclipse-temurin:8-jdk-distro"
               :distro             :distro/distro
               :build-tool         "build-tool"
-              :docker-tag         "openjdk-8-build-tool-1.2.3-distro"
+              :docker-tag         "temurin-8-build-tool-1.2.3-distro"
               :build-tool-version "1.2.3"
               :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"}
-             (variant-map '("openjdk" 8 :distro/distro ["build-tool" "1.2.3"])))))))
+             (variant-map '("eclipse-temurin" 8 :distro/distro ["build-tool" "1.2.3"])))))))
 
 (deftest exclude?-test
   (testing "excludes variant that matches all key-values in any exclusion"

--- a/test/docker_clojure/dockerfile_test.clj
+++ b/test/docker_clojure/dockerfile_test.clj
@@ -17,12 +17,14 @@
   (testing "includes 'FROM base-image'"
     (is (str/includes? (contents cfg/installer-hashes
                                  {:base-image-tag "base:foo"
+                                  :distro         :distro/distro
                                   :build-tool     "boot"
                                   :jdk-version    11})
                        "FROM base:foo")))
   (testing "has no labels (Docker recommends against for base images)"
     (is (not (str/includes? (contents cfg/installer-hashes
                                       {:base-image-tag "base:foo"
+                                       :distro         :distro/distro
                                        :build-tool     "boot"
                                        :maintainer     "Me Myself"
                                        :jdk-version    11})
@@ -31,6 +33,7 @@
     (with-redefs [lein/contents (constantly ["leiningen vs. the ants"])]
       (is (str/includes? (contents cfg/installer-hashes
                                    {:base-image-tag "base:foo"
+                                    :distro         :distro/distro
                                     :build-tool     "lein"
                                     :maintainer     "Me Myself"})
                          "leiningen vs. the ants"))))
@@ -38,6 +41,7 @@
     (with-redefs [boot/contents (constantly ["Booty McBootface"])]
       (is (str/includes? (contents cfg/installer-hashes
                                    {:base-image-tag "base:foo"
+                                    :distro         :distro/distro
                                     :build-tool     "boot"
                                     :maintainer     "Me Myself"})
                          "Booty McBootface"))))
@@ -46,6 +50,7 @@
                                         ["Tools Deps is not a build tool"])]
       (is (str/includes? (contents cfg/installer-hashes
                                    {:base-image-tag "base:foo"
+                                    :distro         :distro/distro
                                     :build-tool     "tools-deps"
                                     :maintainer     "Me Myself"})
                          "Tools Deps is not a build tool")))))


### PR DESCRIPTION
I ran into some issues with the new Ubuntu-based upstream images. Namely, the annoying tendency of Ubuntu to replace APT / DEB packages with snaps. You can't easily install snaps in Docker containers because they require a daemon to be running.

So then I found the eclipse-temurin images' recommended alternate base image suggestion in their docs and it was pretty simple.

This brings back some Debian-based images using that approach. It also enables parallel image builds for testing b/c I got tired of waiting on serialized builds. :)