### PR TITLE
Install curl on Ubuntu explicitly

### DIFF
--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -12,8 +12,8 @@
                  :runtime #{"rlwrap" "make" "git"}}
    :debian      {:build   #{"wget" "curl"}
                  :runtime #{"rlwrap" "make" "git"}}
-   :ubuntu      {:build   #{"wget"}
-                 :runtime #{"rlwrap" "make" "git"}}
+   :ubuntu      {:build   #{}
+                 :runtime #{"rlwrap" "make" "git" "curl"}}
    :alpine      {:build   #{"curl"}
                  :runtime #{"bash" "make" "git"}}})
 

--- a/target/eclipse-temurin-11-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-focal/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-11-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-jammy/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-17-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-jammy/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-21-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-jammy/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-22-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-22-jdk-jammy/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-8-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-focal/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-8-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-jammy/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
 wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009


### PR DESCRIPTION
I saw you said you are working on the fix already, but you might as well consider this fix.

What this does:
- Removes `wget` a build-time dependency for Ubuntu. Since `wget` is present in both Focal and Jammy, it doesn't have to be installed, and it now would not be purged from the resulting image (making Clojure images more consistent with base Temurin images).
- Adds `curl` to runtime dependencies for Ubuntu. This is done to install it during build on Jammy (where it is missing) but not remove it at the end on Focal. Because removing it in the end on Focal may break some user builds.

Ideally, the two distros can be split and have their custom dependencies, but this is a fix for now.