### PR TITLE
Fix: install curl explicitly in tools-deps images

### DIFF
--- a/src/docker_clojure/core.clj
+++ b/src/docker_clojure/core.clj
@@ -231,7 +231,7 @@
     (filter variant-filter (valid-variants))))
 
 (defn run
-  "Entrypoint for exec-fn. TODO: Make -main use this."
+  "Entrypoint for exec-fn."
   [{:keys [cmd args parallelization]}]
   (logger/start)
   (let [variants (generate-variants args)]

--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -8,11 +8,11 @@
                        #(.setExecutable % true false)))
 
 (def distro-deps
-  {:debian-slim {:build   #{"wget" "curl"}
+  {:debian-slim {:build   #{"curl"}
                  :runtime #{"rlwrap" "make" "git"}}
-   :debian      {:build   #{"wget" "curl"}
+   :debian      {:build   #{"curl"}
                  :runtime #{"rlwrap" "make" "git"}}
-   :ubuntu      {:build   #{"wget"}
+   :ubuntu      {:build   #{"curl"}
                  :runtime #{"rlwrap" "make" "git"}}
    :alpine      {:build   #{"curl"}
                  :runtime #{"bash" "make" "git"}}})
@@ -36,7 +36,7 @@
          "RUN \\"]
         (concat-commands install-dep-cmds)
         (concat-commands
-          ["wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"
+          ["curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"
            "sha256sum linux-install-$CLOJURE_VERSION.sh"
            (str "echo \"" (get-in installer-hashes ["tools-deps" build-tool-version]) " *linux-install-$CLOJURE_VERSION.sh\" | sha256sum -c -")
            "chmod +x linux-install-$CLOJURE_VERSION.sh"

--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -12,8 +12,10 @@
                  :runtime #{"rlwrap" "make" "git"}}
    :debian      {:build   #{"curl"}
                  :runtime #{"rlwrap" "make" "git"}}
-   :ubuntu      {:build   #{"curl"}
-                 :runtime #{"rlwrap" "make" "git"}}
+   :ubuntu      {:build   #{}
+                 ;; install curl as a runtime dep b/c we need it at build time
+                 ;; but upstream includes it so we don't want to uninstall it
+                 :runtime #{"rlwrap" "make" "git" "curl"}}
    :alpine      {:build   #{"curl"}
                  :runtime #{"bash" "make" "git"}}})
 

--- a/target/debian-bookworm-11/tools-deps/Dockerfile
+++ b/target/debian-bookworm-11/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bookworm-17/tools-deps/Dockerfile
+++ b/target/debian-bookworm-17/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bookworm-21/latest/Dockerfile
+++ b/target/debian-bookworm-21/latest/Dockerfile
@@ -50,16 +50,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bookworm-21/tools-deps/Dockerfile
+++ b/target/debian-bookworm-21/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bookworm-22/tools-deps/Dockerfile
+++ b/target/debian-bookworm-22/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bookworm-8/tools-deps/Dockerfile
+++ b/target/debian-bookworm-8/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bookworm-slim-11/tools-deps/Dockerfile
+++ b/target/debian-bookworm-slim-11/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bookworm-slim-17/tools-deps/Dockerfile
+++ b/target/debian-bookworm-slim-17/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bookworm-slim-21/tools-deps/Dockerfile
+++ b/target/debian-bookworm-slim-21/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bookworm-slim-22/tools-deps/Dockerfile
+++ b/target/debian-bookworm-slim-22/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bookworm-slim-8/tools-deps/Dockerfile
+++ b/target/debian-bookworm-slim-8/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bullseye-11/tools-deps/Dockerfile
+++ b/target/debian-bullseye-11/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bullseye-17/tools-deps/Dockerfile
+++ b/target/debian-bullseye-17/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bullseye-21/tools-deps/Dockerfile
+++ b/target/debian-bullseye-21/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bullseye-22/tools-deps/Dockerfile
+++ b/target/debian-bullseye-22/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bullseye-8/tools-deps/Dockerfile
+++ b/target/debian-bullseye-8/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bullseye-slim-11/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-11/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bullseye-slim-17/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-17/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bullseye-slim-21/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-21/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bullseye-slim-22/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-22/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/debian-bullseye-slim-8/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-8/tools-deps/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y curl make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-11-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-alpine/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apk add --no-cache curl bash make git && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-11-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-focal/tools-deps/Dockerfile
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-11-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-focal/tools-deps/Dockerfile
@@ -6,16 +6,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-11-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-jammy/tools-deps/Dockerfile
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-11-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-jammy/tools-deps/Dockerfile
@@ -6,16 +6,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-17-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-alpine/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apk add --no-cache curl bash make git && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
@@ -6,16 +6,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-17-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-jammy/tools-deps/Dockerfile
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-17-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-jammy/tools-deps/Dockerfile
@@ -6,16 +6,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-21-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-alpine/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apk add --no-cache curl bash make git && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-21-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-jammy/tools-deps/Dockerfile
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-21-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-jammy/tools-deps/Dockerfile
@@ -6,16 +6,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-22-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-22-jdk-alpine/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apk add --no-cache curl bash make git && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-22-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-22-jdk-jammy/tools-deps/Dockerfile
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-22-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-22-jdk-jammy/tools-deps/Dockerfile
@@ -6,16 +6,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-8-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-alpine/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apk add --no-cache curl bash make git && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-8-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-focal/tools-deps/Dockerfile
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-8-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-focal/tools-deps/Dockerfile
@@ -6,16 +6,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-8-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-jammy/tools-deps/Dockerfile
@@ -14,8 +14,7 @@ echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-in
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
-clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove curl
+clojure -e "(clojure-version)"
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009

--- a/target/eclipse-temurin-8-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-jammy/tools-deps/Dockerfile
@@ -6,16 +6,16 @@ WORKDIR /tmp
 
 RUN \
 apt-get update && \
-apt-get install -y make git rlwrap wget && \
+apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \
 ./linux-install-$CLOJURE_VERSION.sh && \
 rm linux-install-$CLOJURE_VERSION.sh && \
 clojure -e "(clojure-version)" && \
-apt-get purge -y --auto-remove wget
+apt-get purge -y --auto-remove curl
 
 # Docker bug makes rlwrap crash w/o short sleep first
 # Bug: https://github.com/moby/moby/issues/28009


### PR DESCRIPTION
...and use it instead of wget to save on installing that since the tools-deps install script needs curl anyway.

Some upstream images inadvertently removed curl causing this build error: https://github.com/docker-library/official-images/actions/runs/8633451962/job/23666676411?pr=16579

This ensures that curl is installed either way.