### PR TITLE
Make curl fail fast on errors and display them

### DIFF
--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -38,7 +38,7 @@
          "RUN \\"]
         (concat-commands install-dep-cmds)
         (concat-commands
-          ["curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"
+          ["curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"
            "sha256sum linux-install-$CLOJURE_VERSION.sh"
            (str "echo \"" (get-in installer-hashes ["tools-deps" build-tool-version]) " *linux-install-$CLOJURE_VERSION.sh\" | sha256sum -c -")
            "chmod +x linux-install-$CLOJURE_VERSION.sh"

--- a/target/debian-bookworm-11/tools-deps/Dockerfile
+++ b/target/debian-bookworm-11/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bookworm-17/tools-deps/Dockerfile
+++ b/target/debian-bookworm-17/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bookworm-21/latest/Dockerfile
+++ b/target/debian-bookworm-21/latest/Dockerfile
@@ -52,7 +52,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bookworm-21/tools-deps/Dockerfile
+++ b/target/debian-bookworm-21/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bookworm-22/tools-deps/Dockerfile
+++ b/target/debian-bookworm-22/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bookworm-8/tools-deps/Dockerfile
+++ b/target/debian-bookworm-8/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bookworm-slim-11/tools-deps/Dockerfile
+++ b/target/debian-bookworm-slim-11/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bookworm-slim-17/tools-deps/Dockerfile
+++ b/target/debian-bookworm-slim-17/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bookworm-slim-21/tools-deps/Dockerfile
+++ b/target/debian-bookworm-slim-21/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bookworm-slim-22/tools-deps/Dockerfile
+++ b/target/debian-bookworm-slim-22/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bookworm-slim-8/tools-deps/Dockerfile
+++ b/target/debian-bookworm-slim-8/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bullseye-11/tools-deps/Dockerfile
+++ b/target/debian-bullseye-11/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bullseye-17/tools-deps/Dockerfile
+++ b/target/debian-bullseye-17/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bullseye-21/tools-deps/Dockerfile
+++ b/target/debian-bullseye-21/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bullseye-22/tools-deps/Dockerfile
+++ b/target/debian-bullseye-22/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bullseye-8/tools-deps/Dockerfile
+++ b/target/debian-bullseye-8/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bullseye-slim-11/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-11/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bullseye-slim-17/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-17/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bullseye-slim-21/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-21/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bullseye-slim-22/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-22/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/debian-bullseye-slim-8/tools-deps/Dockerfile
+++ b/target/debian-bullseye-slim-8/tools-deps/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-11-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-alpine/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apk add --no-cache curl bash make git && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-11-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-focal/tools-deps/Dockerfile
@@ -8,7 +8,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-11-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-jammy/tools-deps/Dockerfile
@@ -8,7 +8,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-17-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-alpine/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apk add --no-cache curl bash make git && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/tools-deps/Dockerfile
@@ -8,7 +8,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-17-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-jammy/tools-deps/Dockerfile
@@ -8,7 +8,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-21-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-alpine/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apk add --no-cache curl bash make git && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-21-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-jammy/tools-deps/Dockerfile
@@ -8,7 +8,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-22-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-22-jdk-alpine/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apk add --no-cache curl bash make git && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-22-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-22-jdk-jammy/tools-deps/Dockerfile
@@ -8,7 +8,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-8-jdk-alpine/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-alpine/tools-deps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN \
 apk add --no-cache curl bash make git && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-8-jdk-focal/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-focal/tools-deps/Dockerfile
@@ -8,7 +8,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \

--- a/target/eclipse-temurin-8-jdk-jammy/tools-deps/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-jammy/tools-deps/Dockerfile
@@ -8,7 +8,7 @@ RUN \
 apt-get update && \
 apt-get install -y curl make git rlwrap && \
 rm -rf /var/lib/apt/lists/* && \
-curl -sLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
 sha256sum linux-install-$CLOJURE_VERSION.sh && \
 echo "7edee5b12197a2dbe6338e672b109b18164cde84bea1f049ceceed41fc4dd10a *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
 chmod +x linux-install-$CLOJURE_VERSION.sh && \


### PR DESCRIPTION
Implementing a suggestion from the official images reviewers.

This makes curl fail fast on an error (`-f`) and then output the error message even though we have `-s` (`-S`).