### PR TITLE
Include git in Leiningen images

### DIFF
--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -8,13 +8,13 @@
 
 (def distro-deps
   {:debian-slim {:build   #{"wget" "gnupg"}
-                 :runtime #{}}
+                 :runtime #{"git"}}
    :debian      {:build   #{"wget" "gnupg"}
-                 :runtime #{"make"}}
+                 :runtime #{"make" "git"}}
    :ubuntu      {:build   #{"wget" "gnupg"}
-                 :runtime #{"make"}}
+                 :runtime #{"make" "git"}}
    :alpine      {:build   #{"tar" "gnupg" "openssl" "ca-certificates"}
-                 :runtime #{"bash"}}})
+                 :runtime #{"bash" "git"}}})
 
 (def install-deps (partial install-distro-deps distro-deps))
 

--- a/target/debian-bookworm-11/lein/Dockerfile
+++ b/target/debian-bookworm-11/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bookworm-17/lein/Dockerfile
+++ b/target/debian-bookworm-17/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bookworm-21/latest/Dockerfile
+++ b/target/debian-bookworm-21/latest/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bookworm-21/lein/Dockerfile
+++ b/target/debian-bookworm-21/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bookworm-22/lein/Dockerfile
+++ b/target/debian-bookworm-22/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bookworm-8/lein/Dockerfile
+++ b/target/debian-bookworm-8/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bookworm-slim-11/lein/Dockerfile
+++ b/target/debian-bookworm-slim-11/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bookworm-slim-17/lein/Dockerfile
+++ b/target/debian-bookworm-slim-17/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bookworm-slim-21/lein/Dockerfile
+++ b/target/debian-bookworm-slim-21/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bookworm-slim-22/lein/Dockerfile
+++ b/target/debian-bookworm-slim-22/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bookworm-slim-8/lein/Dockerfile
+++ b/target/debian-bookworm-slim-8/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bullseye-11/lein/Dockerfile
+++ b/target/debian-bullseye-11/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bullseye-17/lein/Dockerfile
+++ b/target/debian-bullseye-17/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bullseye-21/lein/Dockerfile
+++ b/target/debian-bullseye-21/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bullseye-22/lein/Dockerfile
+++ b/target/debian-bullseye-22/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bullseye-8/lein/Dockerfile
+++ b/target/debian-bullseye-8/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bullseye-slim-11/lein/Dockerfile
+++ b/target/debian-bullseye-slim-11/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bullseye-slim-17/lein/Dockerfile
+++ b/target/debian-bullseye-slim-17/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bullseye-slim-21/lein/Dockerfile
+++ b/target/debian-bullseye-slim-21/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bullseye-slim-22/lein/Dockerfile
+++ b/target/debian-bullseye-slim-22/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/debian-bullseye-slim-8/lein/Dockerfile
+++ b/target/debian-bullseye-slim-8/lein/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y gnupg wget && \
+apt-get install -y git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/eclipse-temurin-11-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-alpine/lein/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 
 # Download the whole repo as an archive
 RUN set -eux; \
-apk add --no-cache ca-certificates bash tar openssl gnupg && \
+apk add --no-cache ca-certificates bash tar openssl git gnupg && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \

--- a/target/eclipse-temurin-11-jdk-focal/lein/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-focal/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/eclipse-temurin-11-jdk-jammy/lein/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-jammy/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/eclipse-temurin-17-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-alpine/lein/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 
 # Download the whole repo as an archive
 RUN set -eux; \
-apk add --no-cache ca-certificates bash tar openssl gnupg && \
+apk add --no-cache ca-certificates bash tar openssl git gnupg && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \

--- a/target/eclipse-temurin-17-jdk-focal/lein/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-focal/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/eclipse-temurin-17-jdk-jammy/lein/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-jammy/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/eclipse-temurin-21-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-alpine/lein/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 
 # Download the whole repo as an archive
 RUN set -eux; \
-apk add --no-cache ca-certificates bash tar openssl gnupg && \
+apk add --no-cache ca-certificates bash tar openssl git gnupg && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \

--- a/target/eclipse-temurin-21-jdk-jammy/lein/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-jammy/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/eclipse-temurin-22-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-22-jdk-alpine/lein/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 
 # Download the whole repo as an archive
 RUN set -eux; \
-apk add --no-cache ca-certificates bash tar openssl gnupg && \
+apk add --no-cache ca-certificates bash tar openssl git gnupg && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \

--- a/target/eclipse-temurin-22-jdk-jammy/lein/Dockerfile
+++ b/target/eclipse-temurin-22-jdk-jammy/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/eclipse-temurin-8-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-alpine/lein/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 
 # Download the whole repo as an archive
 RUN set -eux; \
-apk add --no-cache ca-certificates bash tar openssl gnupg && \
+apk add --no-cache ca-certificates bash tar openssl git gnupg && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
 echo "Comparing lein-pkg checksum ..." && \

--- a/target/eclipse-temurin-8-jdk-focal/lein/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-focal/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \

--- a/target/eclipse-temurin-8-jdk-jammy/lein/Dockerfile
+++ b/target/eclipse-temurin-8-jdk-jammy/lein/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 # Download the whole repo as an archive
 RUN set -eux; \
 apt-get update && \
-apt-get install -y make gnupg wget && \
+apt-get install -y make git gnupg wget && \
 rm -rf /var/lib/apt/lists/* && \
 mkdir -p $LEIN_INSTALL && \
 wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \


### PR DESCRIPTION
Docker usage on CI often needs git to perform auxiliary actions. For example, CircleCI [doesn't checkout submodules by default](https://circleci.com/docs/configuration-reference/#checkout). Given that tools.deps images already include `git` (because tools.deps supports git-based dependencies), it makes sense to include one in Lein image for parity. It will also be useful for people who use something like https://github.com/reifyhealth/lein-git-down to download git-based deps in Lein.

Practically for me, this will simplify and make more efficient the builds for https://github.com/clojure-emacs/orchard and https://github.com/clojure-emacs/cider-nrepl.