### PR TITLE
Clarify Docker Official Image meaning & status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # docker-clojure
 
-This is the repository for the [official Docker image for Clojure](https://registry.hub.docker.com/_/clojure/).
+This is the repository for the [Docker Official Image for Clojure](https://registry.hub.docker.com/_/clojure/).
+[Docker Official Images](https://docs.docker.com/docker-hub/image-library/trusted-content/#docker-official-images)
+are a curated set of Docker repositories hosted on Docker Hub.
+
 It is automatically pulled and built by Stackbrew into the Docker registry.
 This image runs on OpenJDK 8, 11, 17, and more recent releases and includes
 [Leiningen](http://leiningen.org) or [tools-deps](https://clojure.org/reference/deps_and_cli)


### PR DESCRIPTION
Based on [this Slack conversation](https://clojurians.slack.com/archives/C03S1KBA2/p1732194932147949), it was determined that not everyone understood what it meant to be a "Docker Official Image." This change to the top of the README is intended to clarify that.

Anyone reading this, let me know if you have additional suggestions.