### PR TITLE
Add other upstream architectures

### DIFF
--- a/src/docker_clojure/config.clj
+++ b/src/docker_clojure/config.clj
@@ -90,7 +90,8 @@
   distro type. :default key is a fallback for base images not o/w specified."
   {:default #{:alpine/alpine :ubuntu/jammy :ubuntu/noble}
    "debian" #{:debian-slim/bookworm-slim :debian/bookworm
-              :debian-slim/bullseye-slim :debian/bullseye}})
+              :debian-slim/bullseye-slim :debian/bullseye
+              :debian-slim/trixie-slim :debian/trixie}})
 
 (def architectures
   #{"amd64" "arm64v8"})

--- a/src/docker_clojure/config.clj
+++ b/src/docker_clojure/config.clj
@@ -99,9 +99,9 @@
 (def default-distros
   "The default distro to use for tags that don't specify one, keyed by jdk-version.
   :default is a fallback for jdk versions not o/w specified."
-  {8        :ubuntu/jammy
-   11       :ubuntu/jammy
-   17       :ubuntu/jammy
+  {8        :ubuntu/noble
+   11       :ubuntu/noble
+   17       :ubuntu/noble
    :default :debian/bookworm})
 
 (def build-tools

--- a/target/debian-trixie-11/lein/Dockerfile
+++ b/target/debian-trixie-11/lein/Dockerfile
@@ -1,0 +1,45 @@
+FROM debian:trixie
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.11.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y make git gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "28a1a62668c5f427b413a8677e376affaa995f023b1fcd06e2d4c98ac1df5f3e *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3373CF5E3D8A8243577A7859F && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mkdir -p /root/.lein && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.12.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.12.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/debian-trixie-11/lein/entrypoint
+++ b/target/debian-trixie-11/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-11/tools-deps/Dockerfile
+++ b/target/debian-trixie-11/tools-deps/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:trixie
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.12.0.1530
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "2a113e3a4f1005e05f4d6a6dee24ca317b0115cdd7e6ca6155a76f5ffa5ba35b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+CMD ["clj"]

--- a/target/debian-trixie-11/tools-deps/entrypoint
+++ b/target/debian-trixie-11/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-11/tools-deps/rlwrap.retry
+++ b/target/debian-trixie-11/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-trixie-17/lein/Dockerfile
+++ b/target/debian-trixie-17/lein/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:trixie
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.11.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y make git gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "28a1a62668c5f427b413a8677e376affaa995f023b1fcd06e2d4c98ac1df5f3e *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3373CF5E3D8A8243577A7859F && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mkdir -p /root/.lein && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.12.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.12.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-trixie-17/lein/entrypoint
+++ b/target/debian-trixie-17/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-17/tools-deps/Dockerfile
+++ b/target/debian-trixie-17/tools-deps/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:trixie
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.12.0.1530
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "2a113e3a4f1005e05f4d6a6dee24ca317b0115cdd7e6ca6155a76f5ffa5ba35b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["-M", "--repl"]

--- a/target/debian-trixie-17/tools-deps/entrypoint
+++ b/target/debian-trixie-17/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-17/tools-deps/rlwrap.retry
+++ b/target/debian-trixie-17/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-trixie-21/lein/Dockerfile
+++ b/target/debian-trixie-21/lein/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:trixie
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:21 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.11.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y make git gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "28a1a62668c5f427b413a8677e376affaa995f023b1fcd06e2d4c98ac1df5f3e *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3373CF5E3D8A8243577A7859F && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mkdir -p /root/.lein && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.12.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.12.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-trixie-21/lein/entrypoint
+++ b/target/debian-trixie-21/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-21/tools-deps/Dockerfile
+++ b/target/debian-trixie-21/tools-deps/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:trixie
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:21 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.12.0.1530
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "2a113e3a4f1005e05f4d6a6dee24ca317b0115cdd7e6ca6155a76f5ffa5ba35b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["-M", "--repl"]

--- a/target/debian-trixie-21/tools-deps/entrypoint
+++ b/target/debian-trixie-21/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-21/tools-deps/rlwrap.retry
+++ b/target/debian-trixie-21/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-trixie-24/lein/Dockerfile
+++ b/target/debian-trixie-24/lein/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:trixie
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:24 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.11.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y make git gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "28a1a62668c5f427b413a8677e376affaa995f023b1fcd06e2d4c98ac1df5f3e *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3373CF5E3D8A8243577A7859F && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mkdir -p /root/.lein && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.12.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.12.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-trixie-24/lein/entrypoint
+++ b/target/debian-trixie-24/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-24/tools-deps/Dockerfile
+++ b/target/debian-trixie-24/tools-deps/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:trixie
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:24 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.12.0.1530
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "2a113e3a4f1005e05f4d6a6dee24ca317b0115cdd7e6ca6155a76f5ffa5ba35b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["-M", "--repl"]

--- a/target/debian-trixie-24/tools-deps/entrypoint
+++ b/target/debian-trixie-24/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-24/tools-deps/rlwrap.retry
+++ b/target/debian-trixie-24/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-trixie-8/lein/Dockerfile
+++ b/target/debian-trixie-8/lein/Dockerfile
@@ -1,0 +1,45 @@
+FROM debian:trixie
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.11.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y make git gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "28a1a62668c5f427b413a8677e376affaa995f023b1fcd06e2d4c98ac1df5f3e *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3373CF5E3D8A8243577A7859F && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mkdir -p /root/.lein && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.12.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.12.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/debian-trixie-8/lein/entrypoint
+++ b/target/debian-trixie-8/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-8/tools-deps/Dockerfile
+++ b/target/debian-trixie-8/tools-deps/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:trixie
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.12.0.1530
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "2a113e3a4f1005e05f4d6a6dee24ca317b0115cdd7e6ca6155a76f5ffa5ba35b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+CMD ["clj"]

--- a/target/debian-trixie-8/tools-deps/entrypoint
+++ b/target/debian-trixie-8/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-8/tools-deps/rlwrap.retry
+++ b/target/debian-trixie-8/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-trixie-slim-11/lein/Dockerfile
+++ b/target/debian-trixie-slim-11/lein/Dockerfile
@@ -1,0 +1,45 @@
+FROM debian:trixie-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.11.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y git gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "28a1a62668c5f427b413a8677e376affaa995f023b1fcd06e2d4c98ac1df5f3e *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3373CF5E3D8A8243577A7859F && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mkdir -p /root/.lein && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.12.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.12.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/debian-trixie-slim-11/lein/entrypoint
+++ b/target/debian-trixie-slim-11/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-slim-11/tools-deps/Dockerfile
+++ b/target/debian-trixie-slim-11/tools-deps/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:trixie-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.12.0.1530
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "2a113e3a4f1005e05f4d6a6dee24ca317b0115cdd7e6ca6155a76f5ffa5ba35b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+CMD ["clj"]

--- a/target/debian-trixie-slim-11/tools-deps/entrypoint
+++ b/target/debian-trixie-slim-11/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-slim-11/tools-deps/rlwrap.retry
+++ b/target/debian-trixie-slim-11/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-trixie-slim-17/lein/Dockerfile
+++ b/target/debian-trixie-slim-17/lein/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:trixie-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.11.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y git gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "28a1a62668c5f427b413a8677e376affaa995f023b1fcd06e2d4c98ac1df5f3e *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3373CF5E3D8A8243577A7859F && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mkdir -p /root/.lein && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.12.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.12.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-trixie-slim-17/lein/entrypoint
+++ b/target/debian-trixie-slim-17/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-slim-17/tools-deps/Dockerfile
+++ b/target/debian-trixie-slim-17/tools-deps/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:trixie-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.12.0.1530
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "2a113e3a4f1005e05f4d6a6dee24ca317b0115cdd7e6ca6155a76f5ffa5ba35b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["-M", "--repl"]

--- a/target/debian-trixie-slim-17/tools-deps/entrypoint
+++ b/target/debian-trixie-slim-17/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-slim-17/tools-deps/rlwrap.retry
+++ b/target/debian-trixie-slim-17/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-trixie-slim-21/lein/Dockerfile
+++ b/target/debian-trixie-slim-21/lein/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:trixie-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:21 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.11.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y git gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "28a1a62668c5f427b413a8677e376affaa995f023b1fcd06e2d4c98ac1df5f3e *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3373CF5E3D8A8243577A7859F && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mkdir -p /root/.lein && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.12.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.12.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-trixie-slim-21/lein/entrypoint
+++ b/target/debian-trixie-slim-21/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-slim-21/tools-deps/Dockerfile
+++ b/target/debian-trixie-slim-21/tools-deps/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:trixie-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:21 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.12.0.1530
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "2a113e3a4f1005e05f4d6a6dee24ca317b0115cdd7e6ca6155a76f5ffa5ba35b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["-M", "--repl"]

--- a/target/debian-trixie-slim-21/tools-deps/entrypoint
+++ b/target/debian-trixie-slim-21/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-slim-21/tools-deps/rlwrap.retry
+++ b/target/debian-trixie-slim-21/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-trixie-slim-24/lein/Dockerfile
+++ b/target/debian-trixie-slim-24/lein/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:trixie-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:24 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.11.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y git gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "28a1a62668c5f427b413a8677e376affaa995f023b1fcd06e2d4c98ac1df5f3e *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3373CF5E3D8A8243577A7859F && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mkdir -p /root/.lein && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.12.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.12.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["repl"]

--- a/target/debian-trixie-slim-24/lein/entrypoint
+++ b/target/debian-trixie-slim-24/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-slim-24/tools-deps/Dockerfile
+++ b/target/debian-trixie-slim-24/tools-deps/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:trixie-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:24 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.12.0.1530
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "2a113e3a4f1005e05f4d6a6dee24ca317b0115cdd7e6ca6155a76f5ffa5ba35b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+COPY entrypoint /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+CMD ["-M", "--repl"]

--- a/target/debian-trixie-slim-24/tools-deps/entrypoint
+++ b/target/debian-trixie-slim-24/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-slim-24/tools-deps/rlwrap.retry
+++ b/target/debian-trixie-slim-24/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/target/debian-trixie-slim-8/lein/Dockerfile
+++ b/target/debian-trixie-slim-8/lein/Dockerfile
@@ -1,0 +1,45 @@
+FROM debian:trixie-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV LEIN_VERSION=2.11.2
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Download the whole repo as an archive
+RUN set -eux; \
+apt-get update && \
+apt-get install -y git gnupg wget && \
+rm -rf /var/lib/apt/lists/* && \
+mkdir -p $LEIN_INSTALL && \
+wget -q https://codeberg.org/leiningen/leiningen/raw/tag/$LEIN_VERSION/bin/lein-pkg && \
+echo "Comparing lein-pkg checksum ..." && \
+sha256sum lein-pkg && \
+echo "28a1a62668c5f427b413a8677e376affaa995f023b1fcd06e2d4c98ac1df5f3e *lein-pkg" | sha256sum -c - && \
+mv lein-pkg $LEIN_INSTALL/lein && \
+chmod 0755 $LEIN_INSTALL/lein && \
+export GNUPGHOME="$(mktemp -d)" && \
+export FILENAME_EXT=jar && \
+gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3373CF5E3D8A8243577A7859F && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+wget -q https://codeberg.org/leiningen/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+echo "Verifying file PGP signature..." && \
+gpg --batch --verify leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT && \
+gpgconf --kill all && \
+rm -rf "$GNUPGHOME" leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT.asc && \
+mkdir -p /usr/share/java && \
+mkdir -p /root/.lein && \
+mv leiningen-$LEIN_VERSION-standalone.$FILENAME_EXT /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \
+apt-get purge -y --auto-remove gnupg wget
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+
+# Install clojure 1.12.0 so users don't have to download it every time
+RUN echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.12.0"]])' > project.clj \
+  && lein deps && rm project.clj
+
+CMD ["lein", "repl"]

--- a/target/debian-trixie-slim-8/lein/entrypoint
+++ b/target/debian-trixie-slim-8/lein/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=lein
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-slim-8/tools-deps/Dockerfile
+++ b/target/debian-trixie-slim-8/tools-deps/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:trixie-slim
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+ENV CLOJURE_VERSION=1.12.0.1530
+
+WORKDIR /tmp
+
+RUN \
+apt-get update && \
+apt-get install -y curl make git rlwrap && \
+rm -rf /var/lib/apt/lists/* && \
+curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh && \
+sha256sum linux-install-$CLOJURE_VERSION.sh && \
+echo "2a113e3a4f1005e05f4d6a6dee24ca317b0115cdd7e6ca6155a76f5ffa5ba35b *linux-install-$CLOJURE_VERSION.sh" | sha256sum -c - && \
+chmod +x linux-install-$CLOJURE_VERSION.sh && \
+./linux-install-$CLOJURE_VERSION.sh && \
+rm linux-install-$CLOJURE_VERSION.sh && \
+clojure -e "(clojure-version)" && \
+apt-get purge -y --auto-remove curl
+
+# Docker bug makes rlwrap crash w/o short sleep first
+# Bug: https://github.com/moby/moby/issues/28009
+# As of 2021-09-10 this bug still exists, despite that issue being closed
+COPY rlwrap.retry /usr/local/bin/rlwrap
+
+CMD ["clj"]

--- a/target/debian-trixie-slim-8/tools-deps/entrypoint
+++ b/target/debian-trixie-slim-8/tools-deps/entrypoint
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+entrypoint=clj
+
+cmd=${1:-}
+
+# check if the first arg starts with a hyphen
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+  exec "${entrypoint}" "$@"
+fi
+
+if [[ -n "${cmd}" ]]; then
+  # see if help for the subcommand is successful
+  if "${entrypoint}" "${cmd}" --help >/dev/null 2>&1; then
+    exec "${entrypoint}" "$@"
+  fi
+fi
+
+exec "$@"

--- a/target/debian-trixie-slim-8/tools-deps/rlwrap.retry
+++ b/target/debian-trixie-slim-8/tools-deps/rlwrap.retry
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script works around a Docker bug that prevents rlwrap from starting
+# right when a container is first started. It is intended to replace
+# /usr/bin/rlwrap and also be named rlwrap but earlier in the PATH
+# (e.g. /usr/local/bin).
+
+max_tries=100 # 100 tries is ~1 second
+try=0
+
+while true; do
+  # see if rlwrap can start at all
+  output=$(/usr/bin/rlwrap true 2>&1 >/dev/null)
+  exit_code=$?
+  if [ $exit_code -gt 0 ]; then
+    # it didn't start
+    try=$((try+1))
+    if [ $try -gt $max_tries ]; then
+      # we're at max attempts so output the error and exit w/ the same code
+      echo "$output" >&2
+      exit $exit_code
+    else
+      # wait a bit and try again
+      sleep 0.01
+    fi
+  else
+    # rlwrap can start so let's run it for real
+    exec /usr/bin/rlwrap "$@"
+  fi
+done

--- a/test/docker_clojure/docker_test.clj
+++ b/test/docker_clojure/docker_test.clj
@@ -47,7 +47,7 @@
                                                   "debian")
                             :jdk-version        jdk-version
                             :distro             (if (< jdk-version 21)
-                                                  :ubuntu/jammy
+                                                  :ubuntu/noble
                                                   :debian/bookworm)
                             :build-tool         "tools-deps"
                             :build-tool-version "1.11.1.1155"})]

--- a/test/docker_clojure/manifest_test.clj
+++ b/test/docker_clojure/manifest_test.clj
@@ -4,7 +4,7 @@
 
 (deftest variant->manifest-test
   (testing "generates the correct manifest text for a variant"
-    (is (= "\nTags: temurin-17-noble, temurin-17-tools-deps-1.10.1.478, temurin-17-tools-deps-1.10.1.478-noble, temurin-17-tools-deps-noble\nDirectory: target/eclipse-temurin-17-jdk-noble/tools-deps"
+    (is (= "\nTags: temurin-17-noble, temurin-17-tools-deps, temurin-17-tools-deps-1.10.1.478, temurin-17-tools-deps-1.10.1.478-noble, temurin-17-tools-deps-noble\nDirectory: target/eclipse-temurin-17-jdk-noble/tools-deps"
            (variant->manifest
             {:jdk-version 17, :distro :ubuntu/noble
              :base-image "eclipse-temurin"


### PR DESCRIPTION
This was inspired by #200 (though I'll probably close that as a WONTFIX because 32-bit ARM is not being supported in newer upstream releases and hasn't been needed on the three most recent major revisions of Raspberry Pis anyway).

However, since #240 has landed there are some upstream architectures we can now support by adding some exceptions, adding the new upcoming Debian release (trixie, currently in testing), and relaxing the `:docker-clojure.config/architecture` spec a little.