### PR TITLE
Fix default JDK version tests

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -3,11 +3,10 @@
          org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
                                   :git/sha "b6eb0f2208ab036c0a5d0e7235cb0b09d2feabb7"}}
  :tasks
- {:requires    ([babashka.deps :as deps]
-                [docker-clojure.core :as dc])
+ {:requires    ([docker-clojure.core :as dc])
   clean        (dc/-main "clean")
   dockerfiles  {:depends [clean]
                 :task    (apply dc/-main "dockerfiles" *command-line-args*)}
   manifest     (apply dc/-main "manifest" *command-line-args*)
   build-images {:task    (apply dc/-main "build-images" *command-line-args*)}
-  test         (deref (deps/clojure '-X:test))}}
+  test         (clojure '-X:test)}}

--- a/test/docker_clojure/docker_test.clj
+++ b/test/docker_clojure/docker_test.clj
@@ -35,11 +35,12 @@
 (deftest all-tags-test
   (testing "Generates all-defaults tag for a build tool"
     (let [tags (all-tags {:base-image         "debian"
-                          :jdk-version        21
+                          :jdk-version        cfg/default-jdk-version
                           :distro             :debian/bookworm
                           :build-tool         "tools-deps"
                           :build-tool-version "1.11.1.1155"})]
-      (is ((set tags) "tools-deps"))))
+      (is ((set tags) "tools-deps")
+          (str "Expected \"tools-deps\" to be in " (pr-str tags)))))
   (testing "Generates jdk-version-build-tool tag for every jdk version"
     (are [jdk-version tag]
       (let [tags (all-tags {:base-image         (if (< jdk-version 21)
@@ -55,10 +56,10 @@
       11 "temurin-11-tools-deps"
       17 "temurin-17-tools-deps"
       21 "temurin-21-tools-deps"))
-  (testing "Generates build-tool-distro tag for every distro"
+  (testing "Generates build-tool-distro tag for every distro with default JDK version"
     (are [distro tag]
       (let [tags (all-tags {:base-image         "debian"
-                            :jdk-version        21
+                            :jdk-version        cfg/default-jdk-version
                             :distro             distro
                             :build-tool         "tools-deps"
                             :build-tool-version "1.11.1.1155"})]


### PR DESCRIPTION
...and the exit code for failing `bb run test` commands so that CI will fail again when tests don't pass