### PR TITLE
Remove riscv64 architecture for now

### DIFF
--- a/src/docker_clojure/config.clj
+++ b/src/docker_clojure/config.clj
@@ -94,7 +94,7 @@
               :debian-slim/trixie-slim :debian/trixie}})
 
 (def architectures
-  #{"amd64" "arm64v8" "ppc64le" "riscv64" "s390x"})
+  #{"amd64" "arm64v8" "ppc64le" "s390x"})
 
 (def default-distros
   "The default distro to use for tags that don't specify one, keyed by jdk-version.


### PR DESCRIPTION
There are some complicating factors right now that make supporting this more effort than it is worth. The community interest in it seems low to nonexistent.
More details here: https://github.com/docker-library/official-images/pull/21455#issuecomment-4435157901