### PR TITLE
Format entire project with cljfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,16 @@ jobs:
         git diff --exit-code
     - name: Run tests
       run: bb run test
+
+  format:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install cljfmt
+      uses: DeLaGuardo/setup-clojure@13.4
+      with:
+        cljfmt: latest
+    - uses: actions/checkout@v4
+    - name: Check formatting
+      run: cljfmt check src test bb.edn deps.edn tests.edn

--- a/src/docker_clojure/dockerfile.clj
+++ b/src/docker_clojure/dockerfile.clj
@@ -21,19 +21,19 @@
 
 (defn all-contents [installer-hashes variant]
   (concat
-    ["" "### INSTALL LEIN ###"]
-    (lein/install
-      installer-hashes
-      (assoc variant :build-tool-version
-             (get-in variant [:build-tool-versions "lein"])))
-    ["" "### INSTALL TOOLS-DEPS ###"]
-    (tools-deps/install
-      installer-hashes
-     (assoc variant :build-tool-version
-            (get-in variant [:build-tool-versions "tools-deps"])))
-    [""]
-    (entrypoint variant)
-    ["" "CMD [\"-M\", \"--repl\"]"]))
+   ["" "### INSTALL LEIN ###"]
+   (lein/install
+    installer-hashes
+    (assoc variant :build-tool-version
+           (get-in variant [:build-tool-versions "lein"])))
+   ["" "### INSTALL TOOLS-DEPS ###"]
+   (tools-deps/install
+    installer-hashes
+    (assoc variant :build-tool-version
+           (get-in variant [:build-tool-versions "tools-deps"])))
+   [""]
+   (entrypoint variant)
+   ["" "CMD [\"-M\", \"--repl\"]"]))
 
 (defn copy-java-from-temurin-contents
   [{:keys [jdk-version] :as _variant}]
@@ -86,8 +86,8 @@
     (log "Generating" (str build-dir "/" filename))
     (write-file build-dir filename installer-hashes variant)
     (assoc variant
-      :build-dir build-dir
-      :dockerfile filename)))
+           :build-dir build-dir
+           :dockerfile filename)))
 
 (defn clean-all []
   (sh "sh" "-c" "rm -rf target/*"))

--- a/src/docker_clojure/dockerfile/shared.clj
+++ b/src/docker_clojure/dockerfile/shared.clj
@@ -7,9 +7,9 @@
                    (butlast cmds)
                    cmds)]
     (concat base
-           (map #(str % " && \\")
-                commands)
-           (when end? [(last cmds)]))))
+            (map #(str % " && \\")
+                 commands)
+            (when end? [(last cmds)]))))
 
 (defn get-deps [type distro-deps distro]
   (some->> distro namespace keyword (get distro-deps) type))
@@ -68,7 +68,7 @@
   [{:keys [jdk-version]}]
   (if (>= jdk-version 16)
     (concat
-      ["COPY entrypoint /usr/local/bin/entrypoint"]
-      [""]
-      ["ENTRYPOINT [\"entrypoint\"]"])
+     ["COPY entrypoint /usr/local/bin/entrypoint"]
+     [""]
+     ["ENTRYPOINT [\"entrypoint\"]"])
     nil))

--- a/src/docker_clojure/dockerfile/tools_deps.clj
+++ b/src/docker_clojure/dockerfile/tools_deps.clj
@@ -38,13 +38,13 @@
          "RUN \\"]
         (concat-commands install-dep-cmds)
         (concat-commands
-          ["curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"
-           "sha256sum linux-install-$CLOJURE_VERSION.sh"
-           (str "echo \"" (get-in installer-hashes ["tools-deps" build-tool-version]) " *linux-install-$CLOJURE_VERSION.sh\" | sha256sum -c -")
-           "chmod +x linux-install-$CLOJURE_VERSION.sh"
-           "./linux-install-$CLOJURE_VERSION.sh"
-           "rm linux-install-$CLOJURE_VERSION.sh"
-           "clojure -e \"(clojure-version)\""] (empty? uninstall-dep-cmds))
+         ["curl -fsSLO https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"
+          "sha256sum linux-install-$CLOJURE_VERSION.sh"
+          (str "echo \"" (get-in installer-hashes ["tools-deps" build-tool-version]) " *linux-install-$CLOJURE_VERSION.sh\" | sha256sum -c -")
+          "chmod +x linux-install-$CLOJURE_VERSION.sh"
+          "./linux-install-$CLOJURE_VERSION.sh"
+          "rm linux-install-$CLOJURE_VERSION.sh"
+          "clojure -e \"(clojure-version)\""] (empty? uninstall-dep-cmds))
         (concat-commands uninstall-dep-cmds :end)
         (concat [""] docker-bug-notice
                 ["COPY rlwrap.retry /usr/local/bin/rlwrap"])

--- a/src/docker_clojure/manifest.clj
+++ b/src/docker_clojure/manifest.clj
@@ -8,16 +8,16 @@
   [variant]
   (str/join "\n"
             (conj
-              (remove nil? [(str/join " " (conj ["Tags:"]
-                                                (->> variant
-                                                     docker/all-tags
-                                                     (str/join ", "))))
-                            (when-let [arch (:architectures variant)]
-                              (str/join " " ["Architectures:"
-                                             (str/join ", " arch)]))
-                            (str/join " " ["Directory:"
-                                           (df/build-dir variant)])])
-              nil)))
+             (remove nil? [(str/join " " (conj ["Tags:"]
+                                               (->> variant
+                                                    docker/all-tags
+                                                    (str/join ", "))))
+                           (when-let [arch (:architectures variant)]
+                             (str/join " " ["Architectures:"
+                                            (str/join ", " arch)]))
+                           (str/join " " ["Directory:"
+                                          (df/build-dir variant)])])
+             nil)))
 
 (defn generate
   "Generates Docker manifest file for a given git commit and returns it as a
@@ -29,12 +29,12 @@
                                                  " "))]
     (str/join "\n"
               (concat
-                [(str/join " " [maintainers-label
-                                (str/join maintainers-sep maintainers)])
-                 (str/join " " ["Architectures:" (str/join ", " architectures)])
-                 (str/join " " ["GitRepo:" git-repo])
-                 (str/join " " ["GitCommit:" git-commit])]
+               [(str/join " " [maintainers-label
+                               (str/join maintainers-sep maintainers)])
+                (str/join " " ["Architectures:" (str/join ", " architectures)])
+                (str/join " " ["GitRepo:" git-repo])
+                (str/join " " ["GitCommit:" git-commit])]
 
-                (map variant->manifest merged-arch-variants)
+               (map variant->manifest merged-arch-variants)
 
-                [nil]))))
+               [nil]))))

--- a/src/docker_clojure/variant.clj
+++ b/src/docker_clojure/variant.clj
@@ -17,17 +17,17 @@
 
 (s/def ::variant
   (s/with-gen
-   ::variant-base
-   #(gen/fmap (fn [[v btv]]
-                (if (= ::core/all (:build-tool v))
-                  (-> v ; ::core/all implies docker tag "latest"
-                      (assoc :build-tool-version nil
-                             :build-tool-versions btv)
-                      (dissoc :distro :docker-tag :base-image-tag :base-image))
-                  v))
-              (gen/tuple (s/gen ::variant-base)
-                         (gen/map (s/gen ::cfg/specific-build-tool)
-                                  (s/gen ::cfg/specific-build-tool-version))))))
+    ::variant-base
+    #(gen/fmap (fn [[v btv]]
+                 (if (= ::core/all (:build-tool v))
+                   (-> v ; ::core/all implies docker tag "latest"
+                       (assoc :build-tool-version nil
+                              :build-tool-versions btv)
+                       (dissoc :distro :docker-tag :base-image-tag :base-image))
+                   v))
+               (gen/tuple (s/gen ::variant-base)
+                          (gen/map (s/gen ::cfg/specific-build-tool)
+                                   (s/gen ::cfg/specific-build-tool-version))))))
 
 (s/def ::variants (s/coll-of ::variant))
 
@@ -153,7 +153,7 @@
           (if-let [matching
                    (some #(when
                            (equal-except-architecture? v %)
-                           %)
+                            %)
                          mav)]
             (-> mav
                 (->> (remove #(= % matching)))
@@ -170,16 +170,16 @@
   :args (s/cat :default-architectures ::cfg/architectures
                :variants
                (s/with-gen
-                ::variants
-                #(gen/fmap
-                  (fn [variants]
+                 ::variants
+                 #(gen/fmap
+                   (fn [variants]
                     ;; duplicate variants for each architecture
-                    (mapcat (fn [variant]
-                              (map (fn [arch]
-                                     (assoc variant :architecture arch))
-                                   cfg/architectures))
-                            variants))
-                  (s/gen (s/coll-of ::variant)))))
+                     (mapcat (fn [variant]
+                               (map (fn [arch]
+                                      (assoc variant :architecture arch))
+                                    cfg/architectures))
+                             variants))
+                   (s/gen (s/coll-of ::variant)))))
   :ret  (s/coll-of ::manifest-variant)
   :fn   #(let [ret-count        (-> % :ret count)
                arg-variants     (-> % :args :variants)

--- a/test/docker_clojure/core_test.clj
+++ b/test/docker_clojure/core_test.clj
@@ -30,130 +30,130 @@
                                                (= (:build-tool %) (:build-tool v))))
                                  set)
                             v)
-                 {:jdk-version  11, :distro :debian-slim/buster-slim, :build-tool "lein"
-                  :base-image   "debian" :base-image-tag "debian:buster-slim"
-                  :maintainer   "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag   "temurin-11-lein-2.9.1", :build-tool-version "2.9.1"
-                  :architecture "amd64"}
-                 {:jdk-version  11, :distro :debian-slim/buster-slim, :build-tool "lein"
-                  :base-image   "debian" :base-image-tag "debian:buster-slim"
-                  :maintainer   "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag   "temurin-11-lein-2.9.1", :build-tool-version "2.9.1"
-                  :architecture "arm64v8"}
-                 {:jdk-version        18, :distro :ubuntu/noble
-                  :base-image         "eclipse-temurin"
-                  :base-image-tag     "eclipse-temurin:18-jdk-noble"
-                  :build-tool         "tools-deps"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-18-tools-deps-1.10.1.478"
-                  :build-tool-version "1.10.1.478"
-                  :architecture       "amd64"}
-                 {:jdk-version        18, :distro :ubuntu/noble
-                  :base-image         "eclipse-temurin"
-                  :base-image-tag     "eclipse-temurin:18-jdk-noble"
-                  :build-tool         "tools-deps"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-18-tools-deps-1.10.1.478"
-                  :build-tool-version "1.10.1.478"
-                  :architecture       "arm64v8"}
-                 {:jdk-version  11, :distro :debian/buster, :build-tool "lein"
-                  :base-image   "debian" :base-image-tag "debian:buster"
-                  :maintainer   "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag   "temurin-11-lein-2.9.1-buster", :build-tool-version "2.9.1"
-                  :architecture "amd64"}
-                 {:jdk-version  11, :distro :debian/buster, :build-tool "lein"
-                  :base-image   "debian" :base-image-tag "debian:buster"
-                  :maintainer   "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag   "temurin-11-lein-2.9.1-buster", :build-tool-version "2.9.1"
-                  :architecture "arm64v8"}
-                 {:jdk-version        11, :distro :debian/buster
-                  :base-image         "debian"
-                  :base-image-tag     "debian:buster"
-                  :build-tool         "tools-deps"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-11-tools-deps-1.10.1.478-buster"
-                  :build-tool-version "1.10.1.478"
-                  :architecture       "amd64"}
-                 {:jdk-version        11, :distro :debian/buster
-                  :base-image         "debian"
-                  :base-image-tag     "debian:buster"
-                  :build-tool         "tools-deps"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-11-tools-deps-1.10.1.478-buster"
-                  :build-tool-version "1.10.1.478"
-                  :architecture       "arm64v8"}
-                 {:jdk-version    8, :distro :debian-slim/buster-slim, :build-tool "lein"
-                  :base-image     "debian"
-                  :base-image-tag "debian:buster-slim"
-                  :maintainer     "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag     "temurin-8-lein-2.9.1", :build-tool-version "2.9.1"
-                  :architecture   "amd64"}
-                 {:jdk-version    8, :distro :debian-slim/buster-slim, :build-tool "lein"
-                  :base-image     "debian"
-                  :base-image-tag "debian:buster-slim"
-                  :maintainer     "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag     "temurin-8-lein-2.9.1", :build-tool-version "2.9.1"
-                  :architecture   "arm64v8"}
-                 {:jdk-version        8, :distro :debian-slim/buster-slim
-                  :build-tool         "tools-deps"
-                  :base-image         "debian"
-                  :base-image-tag     "debian:buster-slim"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-8-tools-deps-1.10.1.478"
-                  :build-tool-version "1.10.1.478"
-                  :architecture       "amd64"}
-                 {:jdk-version        8, :distro :debian-slim/buster-slim
-                  :build-tool         "tools-deps"
-                  :base-image         "debian"
-                  :base-image-tag     "debian:buster-slim"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-8-tools-deps-1.10.1.478"
-                  :build-tool-version "1.10.1.478"
-                  :architecture       "arm64v8"}
-                 {:jdk-version        17, :distro :ubuntu/noble, :build-tool "lein"
-                  :base-image         "eclipse-temurin"
-                  :base-image-tag     "eclipse-temurin:17-jdk-noble"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-17-lein-2.9.1"
-                  :build-tool-version "2.9.1"
-                  :architecture       "amd64"}
-                 {:jdk-version        17, :distro :ubuntu/noble, :build-tool "lein"
-                  :base-image         "eclipse-temurin"
-                  :base-image-tag     "eclipse-temurin:17-jdk-noble"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-17-lein-2.9.1"
-                  :build-tool-version "2.9.1"
-                  :architecture       "arm64v8"}
-                 {:jdk-version        17, :distro :alpine/alpine, :build-tool "lein"
-                  :base-image         "eclipse-temurin"
-                  :base-image-tag     "eclipse-temurin:17-jdk-alpine"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-17-lein-2.9.1-alpine"
-                  :build-tool-version "2.9.1"
-                  :architecture       "amd64"}
-                 {:jdk-version        17, :distro :alpine/alpine, :build-tool "lein"
-                  :base-image         "eclipse-temurin"
-                  :base-image-tag     "eclipse-temurin:17-jdk-alpine"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-17-lein-2.9.1-alpine"
-                  :build-tool-version "2.9.1"
-                  :architecture       "arm64v8"}
-                 {:jdk-version        17, :distro :ubuntu/noble
-                  :base-image         "eclipse-temurin"
-                  :base-image-tag     "eclipse-temurin:17-jdk-noble"
-                  :build-tool         "tools-deps"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-17-tools-deps-1.10.1.478"
-                  :build-tool-version "1.10.1.478"
-                  :architecture       "amd64"}
-                 {:jdk-version        17, :distro :ubuntu/noble
-                  :base-image         "eclipse-temurin"
-                  :base-image-tag     "eclipse-temurin:17-jdk-noble"
-                  :build-tool         "tools-deps"
-                  :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
-                  :docker-tag         "temurin-17-tools-deps-1.10.1.478"
-                  :build-tool-version "1.10.1.478"
-                  :architecture       "arm64v8"})))))
+          {:jdk-version  11, :distro :debian-slim/buster-slim, :build-tool "lein"
+           :base-image   "debian" :base-image-tag "debian:buster-slim"
+           :maintainer   "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag   "temurin-11-lein-2.9.1", :build-tool-version "2.9.1"
+           :architecture "amd64"}
+          {:jdk-version  11, :distro :debian-slim/buster-slim, :build-tool "lein"
+           :base-image   "debian" :base-image-tag "debian:buster-slim"
+           :maintainer   "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag   "temurin-11-lein-2.9.1", :build-tool-version "2.9.1"
+           :architecture "arm64v8"}
+          {:jdk-version        18, :distro :ubuntu/noble
+           :base-image         "eclipse-temurin"
+           :base-image-tag     "eclipse-temurin:18-jdk-noble"
+           :build-tool         "tools-deps"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-18-tools-deps-1.10.1.478"
+           :build-tool-version "1.10.1.478"
+           :architecture       "amd64"}
+          {:jdk-version        18, :distro :ubuntu/noble
+           :base-image         "eclipse-temurin"
+           :base-image-tag     "eclipse-temurin:18-jdk-noble"
+           :build-tool         "tools-deps"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-18-tools-deps-1.10.1.478"
+           :build-tool-version "1.10.1.478"
+           :architecture       "arm64v8"}
+          {:jdk-version  11, :distro :debian/buster, :build-tool "lein"
+           :base-image   "debian" :base-image-tag "debian:buster"
+           :maintainer   "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag   "temurin-11-lein-2.9.1-buster", :build-tool-version "2.9.1"
+           :architecture "amd64"}
+          {:jdk-version  11, :distro :debian/buster, :build-tool "lein"
+           :base-image   "debian" :base-image-tag "debian:buster"
+           :maintainer   "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag   "temurin-11-lein-2.9.1-buster", :build-tool-version "2.9.1"
+           :architecture "arm64v8"}
+          {:jdk-version        11, :distro :debian/buster
+           :base-image         "debian"
+           :base-image-tag     "debian:buster"
+           :build-tool         "tools-deps"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-11-tools-deps-1.10.1.478-buster"
+           :build-tool-version "1.10.1.478"
+           :architecture       "amd64"}
+          {:jdk-version        11, :distro :debian/buster
+           :base-image         "debian"
+           :base-image-tag     "debian:buster"
+           :build-tool         "tools-deps"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-11-tools-deps-1.10.1.478-buster"
+           :build-tool-version "1.10.1.478"
+           :architecture       "arm64v8"}
+          {:jdk-version    8, :distro :debian-slim/buster-slim, :build-tool "lein"
+           :base-image     "debian"
+           :base-image-tag "debian:buster-slim"
+           :maintainer     "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag     "temurin-8-lein-2.9.1", :build-tool-version "2.9.1"
+           :architecture   "amd64"}
+          {:jdk-version    8, :distro :debian-slim/buster-slim, :build-tool "lein"
+           :base-image     "debian"
+           :base-image-tag "debian:buster-slim"
+           :maintainer     "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag     "temurin-8-lein-2.9.1", :build-tool-version "2.9.1"
+           :architecture   "arm64v8"}
+          {:jdk-version        8, :distro :debian-slim/buster-slim
+           :build-tool         "tools-deps"
+           :base-image         "debian"
+           :base-image-tag     "debian:buster-slim"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-8-tools-deps-1.10.1.478"
+           :build-tool-version "1.10.1.478"
+           :architecture       "amd64"}
+          {:jdk-version        8, :distro :debian-slim/buster-slim
+           :build-tool         "tools-deps"
+           :base-image         "debian"
+           :base-image-tag     "debian:buster-slim"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-8-tools-deps-1.10.1.478"
+           :build-tool-version "1.10.1.478"
+           :architecture       "arm64v8"}
+          {:jdk-version        17, :distro :ubuntu/noble, :build-tool "lein"
+           :base-image         "eclipse-temurin"
+           :base-image-tag     "eclipse-temurin:17-jdk-noble"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-17-lein-2.9.1"
+           :build-tool-version "2.9.1"
+           :architecture       "amd64"}
+          {:jdk-version        17, :distro :ubuntu/noble, :build-tool "lein"
+           :base-image         "eclipse-temurin"
+           :base-image-tag     "eclipse-temurin:17-jdk-noble"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-17-lein-2.9.1"
+           :build-tool-version "2.9.1"
+           :architecture       "arm64v8"}
+          {:jdk-version        17, :distro :alpine/alpine, :build-tool "lein"
+           :base-image         "eclipse-temurin"
+           :base-image-tag     "eclipse-temurin:17-jdk-alpine"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-17-lein-2.9.1-alpine"
+           :build-tool-version "2.9.1"
+           :architecture       "amd64"}
+          {:jdk-version        17, :distro :alpine/alpine, :build-tool "lein"
+           :base-image         "eclipse-temurin"
+           :base-image-tag     "eclipse-temurin:17-jdk-alpine"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-17-lein-2.9.1-alpine"
+           :build-tool-version "2.9.1"
+           :architecture       "arm64v8"}
+          {:jdk-version        17, :distro :ubuntu/noble
+           :base-image         "eclipse-temurin"
+           :base-image-tag     "eclipse-temurin:17-jdk-noble"
+           :build-tool         "tools-deps"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-17-tools-deps-1.10.1.478"
+           :build-tool-version "1.10.1.478"
+           :architecture       "amd64"}
+          {:jdk-version        17, :distro :ubuntu/noble
+           :base-image         "eclipse-temurin"
+           :base-image-tag     "eclipse-temurin:17-jdk-noble"
+           :build-tool         "tools-deps"
+           :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
+           :docker-tag         "temurin-17-tools-deps-1.10.1.478"
+           :build-tool-version "1.10.1.478"
+           :architecture       "arm64v8"})))))
 
 (deftest exclude?-test
   (testing "excludes variant that matches all key-values in any exclusion"

--- a/test/docker_clojure/docker_test.clj
+++ b/test/docker_clojure/docker_test.clj
@@ -43,27 +43,27 @@
           (str "Expected \"tools-deps\" to be in " (pr-str tags)))))
   (testing "Generates jdk-version-build-tool tag for every jdk version"
     (are [jdk-version tag]
-      (let [tags (all-tags {:base-image         (if (< jdk-version 21)
-                                                  "eclipse-temurin"
-                                                  "debian")
-                            :jdk-version        jdk-version
-                            :distro             (if (< jdk-version 21)
-                                                  :ubuntu/noble
-                                                  :debian/bookworm)
-                            :build-tool         "tools-deps"
-                            :build-tool-version "1.11.1.1155"})]
-        ((set tags) tag))
+         (let [tags (all-tags {:base-image         (if (< jdk-version 21)
+                                                     "eclipse-temurin"
+                                                     "debian")
+                               :jdk-version        jdk-version
+                               :distro             (if (< jdk-version 21)
+                                                     :ubuntu/noble
+                                                     :debian/bookworm)
+                               :build-tool         "tools-deps"
+                               :build-tool-version "1.11.1.1155"})]
+           ((set tags) tag))
       11 "temurin-11-tools-deps"
       17 "temurin-17-tools-deps"
       21 "temurin-21-tools-deps"))
   (testing "Generates build-tool-distro tag for every distro with default JDK version"
     (are [distro tag]
-      (let [tags (all-tags {:base-image         "debian"
-                            :jdk-version        cfg/default-jdk-version
-                            :distro             distro
-                            :build-tool         "tools-deps"
-                            :build-tool-version "1.11.1.1155"})]
-        ((set tags) tag))
+         (let [tags (all-tags {:base-image         "debian"
+                               :jdk-version        cfg/default-jdk-version
+                               :distro             distro
+                               :build-tool         "tools-deps"
+                               :build-tool-version "1.11.1.1155"})]
+           ((set tags) tag))
       :debian/bullseye "tools-deps-bullseye"
       :debian-slim/bullseye-slim "tools-deps-bullseye-slim"
       :debian/bookworm "tools-deps-bookworm"

--- a/test/docker_clojure/dockerfile_test.clj
+++ b/test/docker_clojure/dockerfile_test.clj
@@ -38,7 +38,7 @@
                          "leiningen vs. the ants"))))
   (testing "tools-deps variant includes tools-deps-specific contents"
     (with-redefs [tools-deps/contents (constantly
-                                        ["Tools Deps is not a build tool"])]
+                                       ["Tools Deps is not a build tool"])]
       (is (str/includes? (contents cfg/installer-hashes
                                    {:base-image-tag "base:foo"
                                     :distro         :distro/distro

--- a/test/docker_clojure/variant_test.clj
+++ b/test/docker_clojure/variant_test.clj
@@ -20,7 +20,7 @@
               :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
               :architecture       "i386"}
              (->map '("eclipse-temurin" 8 :distro/distro
-                      ["build-tool" "1.2.3"] "i386"))))
+                                        ["build-tool" "1.2.3"] "i386"))))
 
       (is (= {:jdk-version        22
               :base-image         "debian"
@@ -32,7 +32,7 @@
               :maintainer         "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
               :architecture       "arm64"}
              (->map '("debian" 22 :debian/bookworm
-                      ["tools-deps" "1.12.0.1530"] "arm64"))))
+                               ["tools-deps" "1.12.0.1530"] "arm64"))))
 
       (is (= {:jdk-version         22
               :base-image          "debian"
@@ -45,7 +45,7 @@
               :maintainer          "Paul Lam <paul@quantisan.com> & Wes Morgan <wesmorgan@icloud.com>"
               :architecture        "arm64"}
              (->map '("debian" 22 :debian/bookworm
-                      [::core/all] "arm64")))))))
+                               [::core/all] "arm64")))))))
 
 (deftest exclude?-test
   (testing "gets excluded if contains every key-value pair in exclusion"


### PR DESCRIPTION
Applies `cljfmt` formatting across all project source, test, and EDN files (`src`, `test`, `bb.edn`, `deps.edn`, `tests.edn`).

Changes are whitespace/indentation only — verified with `git diff -w` showing no content changes, and `cljfmt check` passing afterward.

Vendored `.clj-kondo/` configs were intentionally left untouched since they're synced from upstream libraries.