### PR TITLE
Fix node20 and set-output deprecation warnings in official-images-pr workflow

### DIFF
--- a/.github/workflows/official-images-pr.yml
+++ b/.github/workflows/official-images-pr.yml
@@ -60,12 +60,6 @@ jobs:
           path: official-images
       - name: Copy manifest into official-images library
         run: cp docker.manifest official-images/library/clojure
-      - name: Get user email
-        id: email
-        uses: evvanErb/get-github-email-by-username-action@v2.0
-        with:
-          github-username: ${{ github.actor }}
-          token: ${{ secrets.API_TOKEN_GITHUB }}
       - name: Open official-images pull request
         uses: peter-evans/create-pull-request@v8
         with:
@@ -73,7 +67,7 @@ jobs:
           path: official-images
           commit-message: 'Update clojure'
           committer: GitHub Actions <noreply@github.com>
-          author: ${{ github.actor }} <${{ steps.email.outputs.email }}>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           branch: automated-clojure-update
           push-to-fork: Quantisan/official-images
           title: Update clojure


### PR DESCRIPTION
## Problem

The `open-official-images-pr` job emitted two GitHub Actions deprecation warnings, both from the `evvanErb/get-github-email-by-username-action@v2.0` step:

- **Node 20 deprecation** — the action declares `using: 'node16'`, which GitHub forces onto the node20 runtime and warns about.
- **`set-output` deprecation** — its vendored `@actions/core` (`^1.6.0`, pre-1.10.0) emits the deprecated `::set-output::` command. Confirmed in its bundled `dist/index.js` (`issueCommand('set-output', ...)`, no `GITHUB_OUTPUT`).

There's no newer release to bump to — v2.0 is the latest tag and still node16.

## Fix

Remove the email-lookup step entirely and set the PR author to GitHub's stable noreply email, `{actor_id}+{actor}@users.noreply.github.com`. This:

- attributes commits correctly to the triggering user's profile,
- removes a third-party dependency,
- works even when the user has no public email (the old action could return an empty string),
- clears both deprecation warnings.

All remaining actions in the workflow are already on node24 with file-based outputs, and the workflow's own output usage already uses `$GITHUB_OUTPUT`.