### PR TITLE
Pin expected commit when building Leiningen from source

### DIFF
--- a/resources/templates/lein.tmpl
+++ b/resources/templates/lein.tmpl
@@ -4,8 +4,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 {% for dep in install-deps %}{{dep}} && \
 {% endfor %}export GNUPGHOME="$(mktemp -d)" && \
@@ -15,6 +15,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys {{gpg-key}} && \
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "{{lein-commit}}" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/src/docker_clojure/dockerfile/lein.clj
+++ b/src/docker_clojure/dockerfile/lein.clj
@@ -30,10 +30,24 @@
 ;; Leiningen release tags are signed with this key (Phil Hagelberg).
 (def ^:const signing-key "9D13D9426A0814B3373CF5E3D8A8243577A7859F")
 
+;; The commit each release tag is expected to point at. After cloning we assert
+;; HEAD matches, so a moved or re-pointed upstream tag can't slip a different
+;; commit past us (belt-and-suspenders with `git verify-tag`). Requested by the
+;; docker-library/official-images maintainers.
+(def release-commits
+  {"2.13.0" "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030"})
+
+(defn release-commit [version]
+  (or (get release-commits version)
+      (throw (ex-info (str "No known Git commit for Leiningen " version
+                           "; add it to lein/release-commits before building.")
+                      {:lein-version version}))))
+
 (defn install [_installer-hashes {:keys [build-tool-version] :as variant}]
   (render-template
    "templates/lein.tmpl"
    {:lein-version    build-tool-version
+    :lein-commit     (release-commit build-tool-version)
     :clojure-version bundled-clojure-version
     :gpg-key         signing-key
     :install-deps    (install-deps variant)

--- a/target/debian-bookworm-11/lein/Dockerfile
+++ b/target/debian-bookworm-11/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bookworm-17/lein/Dockerfile
+++ b/target/debian-bookworm-17/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bookworm-21/lein/Dockerfile
+++ b/target/debian-bookworm-21/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bookworm-25/latest/Dockerfile
+++ b/target/debian-bookworm-25/latest/Dockerfile
@@ -12,8 +12,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -25,6 +25,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bookworm-25/lein/Dockerfile
+++ b/target/debian-bookworm-25/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bookworm-26/lein/Dockerfile
+++ b/target/debian-bookworm-26/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bookworm-slim-11/lein/Dockerfile
+++ b/target/debian-bookworm-slim-11/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bookworm-slim-17/lein/Dockerfile
+++ b/target/debian-bookworm-slim-17/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bookworm-slim-21/lein/Dockerfile
+++ b/target/debian-bookworm-slim-21/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bookworm-slim-25/lein/Dockerfile
+++ b/target/debian-bookworm-slim-25/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bookworm-slim-26/lein/Dockerfile
+++ b/target/debian-bookworm-slim-26/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bullseye-11/lein/Dockerfile
+++ b/target/debian-bullseye-11/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bullseye-17/lein/Dockerfile
+++ b/target/debian-bullseye-17/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bullseye-21/lein/Dockerfile
+++ b/target/debian-bullseye-21/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bullseye-25/lein/Dockerfile
+++ b/target/debian-bullseye-25/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bullseye-26/lein/Dockerfile
+++ b/target/debian-bullseye-26/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bullseye-slim-11/lein/Dockerfile
+++ b/target/debian-bullseye-slim-11/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bullseye-slim-17/lein/Dockerfile
+++ b/target/debian-bullseye-slim-17/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bullseye-slim-21/lein/Dockerfile
+++ b/target/debian-bullseye-slim-21/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bullseye-slim-25/lein/Dockerfile
+++ b/target/debian-bullseye-slim-25/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-bullseye-slim-26/lein/Dockerfile
+++ b/target/debian-bullseye-slim-26/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-trixie-11/lein/Dockerfile
+++ b/target/debian-trixie-11/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-trixie-17/lein/Dockerfile
+++ b/target/debian-trixie-17/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-trixie-21/lein/Dockerfile
+++ b/target/debian-trixie-21/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-trixie-25/lein/Dockerfile
+++ b/target/debian-trixie-25/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-trixie-26/lein/Dockerfile
+++ b/target/debian-trixie-26/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-trixie-slim-11/lein/Dockerfile
+++ b/target/debian-trixie-slim-11/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-trixie-slim-17/lein/Dockerfile
+++ b/target/debian-trixie-slim-17/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-trixie-slim-21/lein/Dockerfile
+++ b/target/debian-trixie-slim-21/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-trixie-slim-25/lein/Dockerfile
+++ b/target/debian-trixie-slim-25/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/debian-trixie-slim-26/lein/Dockerfile
+++ b/target/debian-trixie-slim-26/lein/Dockerfile
@@ -10,8 +10,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y maven git gnupg && \
@@ -23,6 +23,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-11-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-alpine/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apk add --no-cache ca-certificates bash maven git gnupg && \
 export GNUPGHOME="$(mktemp -d)" && \
@@ -17,6 +17,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-11-jdk-jammy/lein/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-jammy/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -19,6 +19,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-11-jdk-noble/lein/Dockerfile
+++ b/target/eclipse-temurin-11-jdk-noble/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -19,6 +19,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-17-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-alpine/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apk add --no-cache ca-certificates bash maven git gnupg && \
 export GNUPGHOME="$(mktemp -d)" && \
@@ -17,6 +17,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-17-jdk-jammy/lein/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-jammy/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -19,6 +19,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-17-jdk-noble/lein/Dockerfile
+++ b/target/eclipse-temurin-17-jdk-noble/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -19,6 +19,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-21-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-alpine/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apk add --no-cache ca-certificates bash maven git gnupg && \
 export GNUPGHOME="$(mktemp -d)" && \
@@ -17,6 +17,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-21-jdk-jammy/lein/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-jammy/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -19,6 +19,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-21-jdk-noble/lein/Dockerfile
+++ b/target/eclipse-temurin-21-jdk-noble/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -19,6 +19,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-25-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-25-jdk-alpine/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apk add --no-cache ca-certificates bash maven git gnupg && \
 export GNUPGHOME="$(mktemp -d)" && \
@@ -17,6 +17,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-25-jdk-noble/lein/Dockerfile
+++ b/target/eclipse-temurin-25-jdk-noble/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -19,6 +19,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-26-jdk-alpine/lein/Dockerfile
+++ b/target/eclipse-temurin-26-jdk-alpine/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apk add --no-cache ca-certificates bash maven git gnupg && \
 export GNUPGHOME="$(mktemp -d)" && \
@@ -17,6 +17,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \

--- a/target/eclipse-temurin-26-jdk-noble/lein/Dockerfile
+++ b/target/eclipse-temurin-26-jdk-noble/lein/Dockerfile
@@ -6,8 +6,8 @@ ENV LEIN_INSTALL=/usr/local/bin/
 WORKDIR /tmp
 
 # No standalone uberjar is published for this version, so build it from source.
-# Verify Leiningen's GPG-signed release tag, then bootstrap leiningen-core's
-# dependencies with Maven and run `lein uberjar`.
+# Verify Leiningen's GPG-signed release tag and pin the expected commit, then
+# bootstrap leiningen-core's dependencies with Maven and run `lein uberjar`.
 RUN set -eux; \
 apt-get update && \
 apt-get install -y make maven git gnupg && \
@@ -19,6 +19,7 @@ gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 9D13D9426A0814B3
 git clone --depth 1 --branch $LEIN_VERSION https://codeberg.org/leiningen/leiningen.git && \
 cd leiningen && \
 git verify-tag $LEIN_VERSION && \
+[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
 ( cd leiningen-core && mvn -B -q -DskipTests install && mvn -B -q dependency:build-classpath -Dmdep.outputFile=.lein-bootstrap ) && \
 bin/lein uberjar && \
 install -m 0644 target/leiningen-$LEIN_VERSION-standalone.jar /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar && \


### PR DESCRIPTION
Addresses [official-images feedback from @yosifkit](https://github.com/docker-library/official-images/pull/21655#issuecomment-list) on the Leiningen 2.13.0 source-build:

> We recommend to also check that this checked out commit is the expected commit id (`d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030`) on the off chance that the tag is changed.

## What

After `git clone --branch $LEIN_VERSION` + `git verify-tag`, also assert the checked-out `HEAD` matches the expected commit:

```dockerfile
git verify-tag $LEIN_VERSION && \
[ "$(git rev-parse HEAD)" = "d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030" ] && \
```

so a moved or re-pointed upstream tag can't slip a different commit past us (belt-and-suspenders with the existing GPG tag verification).

The expected commit is recorded per release in `lein/release-commits` and threaded into the template; an unknown version throws at generation time rather than silently building an unverifiable image.

## Verification

- Confirmed `refs/tags/2.13.0^{}` on Codeberg dereferences to `d703e4802feb3e5c3fa9ae9f1874fb7a3a3e3030` (what `git rev-parse HEAD` resolves to after checkout).
- Regenerated all lein Dockerfiles (`bb dockerfiles`); cljfmt clean; `bb test` 12 tests / 51 assertions, 0 failures.
- Built the debian-bookworm-slim-11 lein image end-to-end — the commit-pin step passed and `lein version` reports Leiningen 2.13.0.